### PR TITLE
Refactor prime field interface

### DIFF
--- a/src/field/prime_field.rs
+++ b/src/field/prime_field.rs
@@ -1,12 +1,16 @@
-//! Prime field implementation tailored for the `rpp-stark` engine.
-//! Provides deterministic arithmetic over a statically defined prime modulus.
+//! Prime field interface tailored for the `rpp-stark` engine.
+//!
+//! This module intentionally exposes *only* the type- and trait-level
+//! contracts that downstream back-ends must satisfy.  No arithmetic logic
+//! is provided here; consumers are expected to supply constant-time
+//! implementations that respect the documented invariants.
 
 use core::fmt;
 
 /// Metadata describing the underlying field modulus.
 #[derive(Debug, Clone, Copy)]
 pub struct Modulus {
-    /// Prime modulus value.
+    /// Prime modulus value in canonical representation.
     pub value: u64,
     /// Indicates whether the modulus passed primality checks during configuration.
     pub is_prime: bool,
@@ -23,90 +27,91 @@ impl Modulus {
 pub const DEFAULT_MODULUS: Modulus = Modulus::new(0xffffffff00000001, true);
 
 /// Field element represented as a canonical value modulo the prime.
+///
+/// # Representation
+///
+/// * `FieldElement` is a transparent wrapper around a raw `u64`.  When the
+///   element is in canonical (non-Montgomery) form the wrapped integer must be
+///   within the range `[0, MODULUS.value)`.
+/// * Montgomery form encodes elements as `a * R mod MODULUS`, where `R = 2^64`.
+/// * Serialization uses **little-endian** byte order for canonical
+///   representations; Montgomery encodings are documented separately by the
+///   conversion traits.
+///
+/// # Safety & Auditing
+///
+/// The type itself performs no runtime validation.  Implementations of the
+/// provided traits must enforce the documented invariants and perform
+/// constant-time assertions where required by `ConstantTimeAssertions`.
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
-pub struct FieldElement {
-    /// Canonical representative in the range `[0, modulus)`.
-    value: u64,
-}
-
-impl FieldElement {
-    /// Returns the additive identity.
-    pub const fn zero() -> Self {
-        Self { value: 0 }
-    }
-
-    /// Returns the multiplicative identity.
-    pub const fn one() -> Self {
-        Self { value: 1 }
-    }
-
-    /// Constructs an element from a raw value reduced modulo the default modulus.
-    pub fn new(value: u64) -> Self {
-        Self {
-            value: value % DEFAULT_MODULUS.value,
-        }
-    }
-
-    /// Exposes the underlying canonical value.
-    pub fn as_u64(&self) -> u64 {
-        self.value
-    }
-
-    /// Computes the modular addition of two field elements.
-    pub fn add(self, other: Self) -> Self {
-        let modulus = DEFAULT_MODULUS.value;
-        let sum = self.value.wrapping_add(other.value);
-        let mut result = sum;
-        if result >= modulus || sum < self.value {
-            result = result.wrapping_sub(modulus);
-        }
-        Self { value: result }
-    }
-
-    /// Computes modular subtraction.
-    pub fn sub(self, other: Self) -> Self {
-        let modulus = DEFAULT_MODULUS.value;
-        let mut result = self.value.wrapping_sub(other.value);
-        if self.value < other.value {
-            result = result.wrapping_add(modulus);
-        }
-        Self { value: result }
-    }
-
-    /// Computes modular multiplication using 128-bit widening.
-    pub fn mul(self, other: Self) -> Self {
-        let modulus = DEFAULT_MODULUS.value as u128;
-        let product = (self.value as u128) * (other.value as u128);
-        Self {
-            value: (product % modulus) as u64,
-        }
-    }
-
-    /// Computes modular exponentiation via square-and-multiply.
-    pub fn pow(self, mut exp: u64) -> Self {
-        let mut result = Self::one();
-        let mut base = self;
-        while exp > 0 {
-            if exp & 1 == 1 {
-                result = result.mul(base);
-            }
-            base = base.mul(base);
-            exp >>= 1;
-        }
-        result
-    }
-
-    /// Computes the multiplicative inverse using Fermat's little theorem.
-    pub fn inv(self) -> Option<Self> {
-        if self.value == 0 {
-            return None;
-        }
-        Some(self.pow(DEFAULT_MODULUS.value - 2))
-    }
-}
+pub struct FieldElement(pub u64);
 
 impl fmt::Debug for FieldElement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("FieldElement").field(&self.value).finish()
+        f.debug_tuple("FieldElement").field(&self.0).finish()
     }
+}
+
+impl FieldElement {
+    /// Canonical prime modulus associated with this field.
+    pub const MODULUS: Modulus = DEFAULT_MODULUS;
+    /// Montgomery radix `R = 2^64 mod MODULUS`.
+    pub const R: u64 = 0xffffffff;
+    /// Precomputed `R^2 mod MODULUS` used for Montgomery conversions.
+    pub const R2: u64 = 0xfffffffe00000001;
+    /// `-MODULUS^{-1} mod 2^64`, the Montgomery reduction parameter.
+    pub const MONTGOMERY_INV: u64 = 0xfffffffeffffffff;
+    /// Designated generator for the multiplicative subgroup.
+    pub const GENERATOR: FieldElement = FieldElement(3);
+    /// Additive identity in canonical form.
+    pub const ZERO: FieldElement = FieldElement(0);
+    /// Multiplicative identity in canonical form.
+    pub const ONE: FieldElement = FieldElement(1);
+}
+
+/// Trait describing the high-level arithmetic contract for field elements.
+pub trait FieldElementOps: Sized {
+    /// Adds two canonical field elements, returning the canonical representative.
+    fn add(&self, rhs: &Self) -> Self;
+    /// Subtracts `rhs` from `self` in canonical form.
+    fn sub(&self, rhs: &Self) -> Self;
+    /// Computes the additive inverse of `self`.
+    fn neg(&self) -> Self;
+    /// Multiplies two field elements.
+    fn mul(&self, rhs: &Self) -> Self;
+    /// Squares the field element.
+    fn square(&self) -> Self;
+    /// Computes the multiplicative inverse, returning `None` for zero.
+    fn inv(&self) -> Option<Self>;
+}
+
+/// Trait capturing Montgomery encoding/decoding contracts.
+pub trait MontgomeryConvertible: Sized {
+    /// Converts a canonical element into Montgomery form.
+    fn to_montgomery(&self) -> Self;
+    /// Converts an element from Montgomery form back to canonical representation.
+    fn from_montgomery(&self) -> Self;
+}
+
+/// Trait defining serialization requirements for field elements.
+pub trait CanonicalSerialize: Sized {
+    /// Canonical serialization output type (e.g. `[u8; 8]`).
+    type Bytes;
+
+    /// Serializes the element into canonical little-endian bytes.
+    fn to_bytes(&self) -> Self::Bytes;
+
+    /// Attempts to deserialize from canonical little-endian bytes.
+    fn from_bytes(bytes: &Self::Bytes) -> Option<Self>;
+}
+
+/// Trait collecting constant-time auditing assertions required by higher layers.
+pub trait ConstantTimeAssertions {
+    /// Ensures the element is strictly less than the field modulus in constant time.
+    fn assert_lt_modulus(&self);
+    /// Ensures the element is *not* the additive identity in constant time.
+    fn assert_nonzero(&self);
+    /// Ensures the element is a valid canonical representative (or panics/logs otherwise).
+    fn assert_canonical(&self);
 }


### PR DESCRIPTION
## Summary
- replace prime field element implementation with a trait-driven interface specification
- document canonical representation, endianness, and Montgomery constants
- introduce traits for arithmetic, Montgomery conversion, serialization, and constant-time assertions

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68e185be784c8326bd0254200f548639