### PR TITLE
Document descriptive polynomial and FFT interfaces

### DIFF
--- a/src/fft/ifft.rs
+++ b/src/fft/ifft.rs
@@ -1,29 +1,28 @@
 //! Inverse FFT routines for polynomial reconstruction.
-//! Provides deterministic algorithms for use in the FRI commitment scheme.
+//!
+//! The module documents the inverse transform side of the radix-2 pipeline.
+//! Implementations operate entirely in Montgomery space to keep consistency with
+//! forward transforms and polynomial storage.  Deterministic chunking mirrors the
+//! forward transform to preserve transcript stability in interactive protocols.
 
-use crate::field::{polynomial::Polynomial, FieldElement};
-use crate::StarkError;
-use crate::StarkResult;
+use super::{EvaluationDomain, Radix2Domain};
 
-/// Inverse FFT operator placeholder.
-#[derive(Debug, Clone)]
-pub struct InverseFft {
-    /// Domain size used for interpolation.
-    pub domain_size: usize,
+/// Trait documenting inverse FFT execution contracts.
+pub trait Ifft<F> {
+    /// Associated evaluation domain.
+    type Domain: EvaluationDomain<F>;
+
+    /// Returns the evaluation domain descriptor used during interpolation.
+    fn domain(&self) -> &Self::Domain;
+
+    /// Executes the inverse transform, mutating the provided evaluations in
+    /// place.
+    fn inverse(&self, values: &mut [F]);
 }
 
-impl InverseFft {
-    /// Creates a new inverse FFT operator with the provided domain size.
-    pub fn new(domain_size: usize) -> Self {
-        Self { domain_size }
-    }
-
-    /// Reconstructs a polynomial from evaluation points.
-    pub fn interpolate(&self, evaluations: &[FieldElement]) -> StarkResult<Polynomial> {
-        if evaluations.is_empty() || evaluations.len() != self.domain_size {
-            return Err(StarkError::InvalidInput("invalid evaluation length"));
-        }
-        // Placeholder deterministic interpolation using direct assignment.
-        Ok(Polynomial::new(evaluations.to_vec()))
-    }
+/// Descriptor for radix-2 inverse FFT plans.
+#[derive(Debug, Clone, Copy)]
+pub struct Radix2InverseFft<F> {
+    /// Domain carrying ordering and generator metadata.
+    pub domain: Radix2Domain<F>,
 }

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -1,8 +1,102 @@
 //! Fast Fourier Transform utilities for the `rpp-stark` engine.
-//! Includes low-degree extension (LDE) and inverse FFT operations for polynomial evaluation.
+//!
+//! This module captures the type-level contracts for radix-2 FFT execution
+//! without providing concrete algorithms.  The documented traits explicitly
+//! state how Montgomery-encoded field elements, generator tables, and
+//! deterministic chunking interplay to guarantee reproducibility across
+//! platforms.
+
+use core::marker::PhantomData;
+
+use crate::field::FieldElement;
 
 pub mod ifft;
 pub mod lde;
 
-pub use ifft::InverseFft;
-pub use lde::LowDegreeExtension;
+pub use ifft::Ifft;
+
+/// Maximum supported radix-2 domain size expressed as `log2(n)`.
+///
+/// Implementations are expected to enforce this bound when building FFT plans
+/// to ensure generator tables remain precomputed and cache-friendly.
+pub const RADIX2_MAX_LOG2_SIZE: usize = 32;
+
+/// Ordering used when iterating evaluation domain elements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Radix2Ordering {
+    /// Natural (lexicographic) ordering.
+    Natural,
+    /// Bit-reversed ordering compatible with iterative Cooley-Tukey FFTs.
+    BitReversed,
+}
+
+/// Placeholder table describing radix-2 generators in Montgomery form.
+#[derive(Debug, Clone, Copy)]
+pub struct Radix2GeneratorTable<F> {
+    /// Successive powers of the primitive root used for the forward FFT.
+    pub forward: &'static [F],
+    /// Successive powers of the inverse root used for the inverse FFT.
+    pub inverse: &'static [F],
+    /// Marker tying the table to the field implementation.
+    pub _field: PhantomData<F>,
+}
+
+impl<F> Radix2GeneratorTable<F> {
+    /// Returns an empty placeholder table.
+    pub const fn empty() -> Self {
+        Self {
+            forward: &[],
+            inverse: &[],
+            _field: PhantomData,
+        }
+    }
+}
+
+/// Canonical radix-2 evaluation domain descriptor.
+#[derive(Debug, Clone, Copy)]
+pub struct Radix2Domain<F> {
+    /// Logarithm of the domain size.
+    pub log2_size: usize,
+    /// Element ordering used during iteration.
+    pub ordering: Radix2Ordering,
+    /// Precomputed generator tables in Montgomery form.
+    pub generators: Radix2GeneratorTable<F>,
+}
+
+/// Trait describing evaluation domains used for FFTs.
+pub trait EvaluationDomain<F> {
+    /// Returns the logarithm of the domain size.
+    fn log2_size(&self) -> usize;
+
+    /// Returns the concrete ordering of the domain elements.
+    fn ordering(&self) -> Radix2Ordering;
+
+    /// Returns the generator table used for twiddle factor lookups.
+    fn generators(&self) -> &Radix2GeneratorTable<F>;
+
+    /// Provides a canonical description of the deterministic chunking strategy
+    /// that must be used when parallelizing FFT butterflies.  The description is
+    /// returned as a free-form string to keep the API descriptive while allowing
+    /// implementors to document platform specific nuances (e.g. Montgomery
+    /// conversion boundaries).
+    fn chunking_description(&self) -> &'static str;
+}
+
+/// Trait documenting forward FFT execution contracts.
+pub trait Fft<F> {
+    /// Associated evaluation domain for the plan.
+    type Domain: EvaluationDomain<F>;
+
+    /// Returns the evaluation domain descriptor used by the plan.
+    fn domain(&self) -> &Self::Domain;
+
+    /// Executes the forward transform in-place on Montgomery encoded values.
+    fn forward(&self, values: &mut [F]);
+}
+
+/// Canonical empty generator table for the default field.
+pub const RADIX2_GENERATORS: Radix2GeneratorTable<FieldElement> = Radix2GeneratorTable {
+    forward: &[],
+    inverse: &[],
+    _field: PhantomData,
+};

--- a/src/field/polynomial.rs
+++ b/src/field/polynomial.rs
@@ -1,37 +1,82 @@
 //! Polynomial utilities operating over the prime field.
-//! The module provides deterministic arithmetic for trace and constraint polynomials.
+//!
+//! The module defines *descriptive* types and traits that document how
+//! polynomial data is expected to flow through the `rpp-stark` engine.  No
+//! arithmetic logic is provided; back-ends embed the required algorithms while
+//! conforming to the contracts outlined here.  Coefficients are assumed to live
+//! in Montgomery representation to avoid redundant conversions when switching
+//! between field arithmetic and FFT-based evaluation domains.
 
 use super::FieldElement;
 
 /// Dense polynomial represented by coefficients in ascending order.
+///
+/// # Representation
+///
+/// * `coefficients[0]` stores the constant term, and higher indices correspond
+///   to increasing powers of `x`.
+/// * All coefficients are encoded in Montgomery form to keep multiplication and
+///   accumulation routines compatible with FFT twiddle factors that are also
+///   precomputed in Montgomery form.
+/// * Consumers are expected to follow the deterministic chunking strategy
+///   documented by [`PolynomialChunking`] when distributing work across threads.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Polynomial {
-    /// Coefficients starting from the constant term.
+    /// Backing storage for the dense coefficient vector.
     pub coefficients: Vec<FieldElement>,
 }
 
-impl Polynomial {
-    /// Constructs a polynomial from raw coefficients.
-    pub fn new(coefficients: Vec<FieldElement>) -> Self {
-        Self { coefficients }
-    }
+/// Lightweight view into an existing polynomial.
+///
+/// This type enables borrowing coefficient slices without requiring an owned
+/// allocation.  It mirrors [`Polynomial`] in layout but leaves lifetime
+/// management to the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PolynomialView<'a> {
+    /// Borrowed coefficients in Montgomery form.
+    pub coefficients: &'a [FieldElement],
+}
 
-    /// Evaluates the polynomial at the provided point using Horner's method.
-    pub fn evaluate(&self, point: FieldElement) -> FieldElement {
-        let mut result = FieldElement::zero();
-        for coeff in self.coefficients.iter().rev() {
-            result = result.mul(point).add(*coeff);
-        }
-        result
-    }
+/// Trait describing evaluation of a polynomial at a single point.
+pub trait PolynomialEvaluation {
+    /// Evaluates the polynomial at the provided point.
+    ///
+    /// Implementations typically rely on Horner's method while remaining within
+    /// Montgomery form for intermediate products.  Any domain-specific
+    /// acceleration (e.g. batching, SIMD) must preserve the deterministic
+    /// ordering guarantees defined by [`PolynomialChunking`].
+    fn evaluate_at(&self, point: &FieldElement) -> FieldElement;
+}
 
-    /// Returns the degree of the polynomial or `None` if the polynomial is zero.
-    pub fn degree(&self) -> Option<usize> {
-        for (idx, coeff) in self.coefficients.iter().enumerate().rev() {
-            if coeff.as_u64() != 0 {
-                return Some(idx);
-            }
-        }
-        None
-    }
+/// Trait exposing degree queries for a polynomial.
+pub trait PolynomialDegree {
+    /// Returns the degree of the polynomial or `None` if it is identically
+    /// zero.
+    fn degree(&self) -> Option<usize>;
+}
+
+/// Trait providing access to raw coefficients.
+pub trait PolynomialCoefficients {
+    /// Returns an immutable view over all coefficients in Montgomery form.
+    fn coefficients(&self) -> &[FieldElement];
+
+    /// Fetches the coefficient at `index`, returning `None` when the index lies
+    /// outside the stored dense range.
+    fn coefficient(&self, index: usize) -> Option<FieldElement>;
+}
+
+/// Trait documenting deterministic chunking rules used for parallel execution.
+///
+/// Chunk boundaries must be reproducible across platforms to maintain
+/// transcript consistency in interactive oracle proofs.  Implementations should
+/// always derive offsets from the canonical dense layout of the polynomial and
+/// avoid heuristics that depend on runtime characteristics such as CPU core
+/// count.
+pub trait PolynomialChunking {
+    /// Returns the canonical chunk size used for partitioning the coefficient
+    /// vector.
+    fn chunk_size(&self) -> usize;
+
+    /// Returns the starting coefficient index for the provided chunk.
+    fn chunk_offset(&self, chunk_index: usize) -> usize;
 }


### PR DESCRIPTION
## Summary
- refactor the polynomial module into descriptive data structures and trait contracts, highlighting Montgomery storage and deterministic chunking
- define radix-2 FFT domain metadata, generator tables, and trait-based interfaces for forward and inverse plans without execution logic
- document low-degree extension APIs to align with the descriptive FFT and polynomial contracts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1863cf75c8326bbcd935b9a0ae6a1