### PR TITLE
Document Poseidon and BLAKE3 parameter interfaces

### DIFF
--- a/src/hash/config.rs
+++ b/src/hash/config.rs
@@ -1,9 +1,25 @@
 //! Hash configuration definitions shared across prover and verifier.
 //! Parameters ensure deterministic hash usage within transcripts and commitments.
 
+/// Version identifier for the Poseidon parameter set with `t = 12`.
+pub const POSEIDON_PARAMETERS_V1_ID: &str = "poseidon-v1-t12-r8-c4-alpha5-rf8-rp56";
+
+/// Domain separation tag applied to arithmetic hashes performed inside the field.
+pub const POSEIDON_ARITHMETIC_DOMAIN_TAG: &[u8] = b"rpp-stark:poseidon:arith";
+
+/// Version identifier for the BLAKE3 transcript hash used for commitments.
+pub const BLAKE3_PARAMETERS_V1_ID: &str = "blake3-v1-transcript";
+
+/// Domain separation tag for BLAKE3 when hashing external commitments or transcript data.
+pub const BLAKE3_COMMITMENT_DOMAIN_TAG: &[u8] = b"rpp-stark:blake3:commit";
+
 /// Poseidon parameter set descriptor.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct PoseidonParameters {
+    /// Version identifier matching [`POSEIDON_PARAMETERS_V1_ID`].
+    pub id: &'static str,
+    /// Domain separation tag for arithmetic sponge usage.
+    pub domain_tag: &'static [u8],
     /// Number of full rounds in the permutation.
     pub full_rounds: usize,
     /// Number of partial rounds in the permutation.
@@ -14,8 +30,16 @@ pub struct PoseidonParameters {
 
 impl PoseidonParameters {
     /// Creates a new parameter set with deterministic defaults.
-    pub fn new(full_rounds: usize, partial_rounds: usize, width: usize) -> Self {
+    pub const fn new(
+        id: &'static str,
+        domain_tag: &'static [u8],
+        full_rounds: usize,
+        partial_rounds: usize,
+        width: usize,
+    ) -> Self {
         Self {
+            id,
+            domain_tag,
             full_rounds,
             partial_rounds,
             width,
@@ -24,21 +48,23 @@ impl PoseidonParameters {
 }
 
 /// Blake3 parameter descriptor for transcript usage.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Blake3Parameters {
-    /// Fixed domain separation label.
-    pub label: &'static [u8],
+    /// Version identifier matching [`BLAKE3_PARAMETERS_V1_ID`].
+    pub id: &'static str,
+    /// Fixed domain separation label applied to every message chunk.
+    pub domain_tag: &'static [u8],
 }
 
 impl Blake3Parameters {
     /// Creates a new descriptor.
-    pub const fn new(label: &'static [u8]) -> Self {
-        Self { label }
+    pub const fn new(id: &'static str, domain_tag: &'static [u8]) -> Self {
+        Self { id, domain_tag }
     }
 }
 
 /// Aggregate hash parameters used by the STARK engine.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct HashParameters {
     /// Poseidon permutation configuration.
     pub poseidon: PoseidonParameters,
@@ -48,7 +74,7 @@ pub struct HashParameters {
 
 impl HashParameters {
     /// Constructs aggregate parameters.
-    pub fn new(poseidon: PoseidonParameters, blake3: Blake3Parameters) -> Self {
+    pub const fn new(poseidon: PoseidonParameters, blake3: Blake3Parameters) -> Self {
         Self { poseidon, blake3 }
     }
 }

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -6,7 +6,13 @@ pub mod config;
 pub mod merkle;
 pub mod poseidon;
 
-pub use blake3::Blake3Hasher;
-pub use config::{Blake3Parameters, HashParameters, PoseidonParameters};
+pub use blake3::TranscriptHasher;
+pub use config::{
+    Blake3Parameters, HashParameters, PoseidonParameters, BLAKE3_COMMITMENT_DOMAIN_TAG,
+    BLAKE3_PARAMETERS_V1_ID, POSEIDON_ARITHMETIC_DOMAIN_TAG, POSEIDON_PARAMETERS_V1_ID,
+};
 pub use merkle::{MerklePath, MerkleTree};
-pub use poseidon::PoseidonState;
+pub use poseidon::{
+    PoseidonMdsMatrix, PoseidonMdsMatrixV1, PoseidonPermutationOrder, PoseidonPermutationOrderV1,
+    PoseidonPermutationSpec, PoseidonRoundConstants, PoseidonRoundConstantsV1, PoseidonSpecV1,
+};

--- a/src/hash/poseidon.rs
+++ b/src/hash/poseidon.rs
@@ -1,59 +1,135 @@
-//! Poseidon hash permutation for field elements.
-//! The implementation is a placeholder outlining the deterministic interface.
+//! Poseidon hash permutation parameter declarations.
+//!
+//! This module intentionally exposes the structure of the Poseidon permutation used by
+//! the STARK stack without providing an executable permutation.  Consumers rely on the
+//! documented constants to wire a field-arithmetic implementation in host environments
+//! that have access to the actual constants.
 
-use super::config::PoseidonParameters;
 use crate::field::FieldElement;
-use crate::{StarkError, StarkResult};
 
-/// Poseidon state representation used during hashing.
-#[derive(Debug, Clone)]
-pub struct PoseidonState {
-    /// Current state elements.
-    pub elements: Vec<FieldElement>,
-    /// Poseidon parameters controlling the permutation.
-    pub parameters: PoseidonParameters,
+/// Describes a Poseidon MDS matrix without committing to concrete coefficients.
+///
+/// Implementations document how the matrix is structured and which field the entries
+/// live in.  The actual coefficients are expected to be provided in environments that
+/// have access to the full parameter set; in this repository we merely declare the
+/// interface so downstream crates can plug in verified constants.
+pub trait PoseidonMdsMatrix {
+    /// Field over which the matrix is defined (the STARK base field).
+    type Field;
+
+    /// Width of the matrix which matches the width of the Poseidon state `t`.
+    const WIDTH: usize;
 }
 
-impl PoseidonState {
-    /// Creates a new Poseidon state initialised with zero elements.
-    pub fn new(parameters: PoseidonParameters) -> Self {
-        let mut elements = Vec::with_capacity(parameters.width);
-        elements.resize(parameters.width, FieldElement::zero());
-        Self {
-            elements,
-            parameters,
-        }
-    }
+/// Declares the round constants for a Poseidon permutation without enumerating them.
+///
+/// Implementations are required to specify how many full and partial rounds the
+/// permutation executes and to expose a handle to the constant schedule.  The constants
+/// themselves remain out of scope for this crate in order to keep the implementation
+/// side-effect free.
+pub trait PoseidonRoundConstants {
+    /// Field element type used in the constant schedule.
+    type Field;
 
-    /// Absorbs field elements into the state using a deterministic sponge interface.
-    pub fn absorb(&mut self, input: &[FieldElement]) {
-        for (i, value) in input.iter().enumerate() {
-            let index = i % self.elements.len();
-            self.elements[index] = self.elements[index].add(*value);
-        }
-    }
+    /// Total number of constants attached to full rounds.
+    const FULL_ROUND_COUNT: usize;
 
-    /// Applies the Poseidon permutation rounds.
-    pub fn permute(&mut self) {
-        for _ in 0..self.parameters.full_rounds {
-            for element in &mut self.elements {
-                *element = element.pow(5);
-            }
-        }
-    }
+    /// Total number of constants attached to partial rounds.
+    const PARTIAL_ROUND_COUNT: usize;
+}
 
-    /// Extracts a deterministic field element from the state.
-    pub fn squeeze(&mut self) -> FieldElement {
-        self.permute();
-        self.elements[0]
-    }
+/// Declares the permutation schedule and state geometry for Poseidon.
+///
+/// The trait bundles the width, rate, capacity, S-Box exponent `ALPHA` and the round
+/// configuration.  Production implementations can attach concrete MDS matrices and
+/// round constants by implementing [`PoseidonMdsMatrix`] and [`PoseidonRoundConstants`].
+pub trait PoseidonPermutationSpec {
+    /// Field type the permutation operates over.
+    type Field;
 
-    /// Convenience helper producing a hash digest from an input slice.
-    pub fn hash(&mut self, input: &[FieldElement]) -> StarkResult<FieldElement> {
-        if input.is_empty() {
-            return Err(StarkError::InvalidInput("poseidon input cannot be empty"));
-        }
-        self.absorb(input);
-        Ok(self.squeeze())
-    }
+    /// Rate of the sponge construction (number of elements absorbed per permutation).
+    const RATE: usize;
+
+    /// Capacity of the sponge construction ensuring cryptographic security.
+    const CAPACITY: usize;
+
+    /// State width `t = RATE + CAPACITY`.
+    const WIDTH: usize;
+
+    /// Exponent of the S-Box used during non-linear full rounds (`\alpha = 5`).
+    const ALPHA: u32;
+
+    /// Number of full rounds (`r_f = 8`).
+    const FULL_ROUNDS: usize;
+
+    /// Number of partial rounds (`r_p = 56`).
+    const PARTIAL_ROUNDS: usize;
+
+    /// Declaration of the MDS matrix used between rounds.
+    type MdsMatrix: PoseidonMdsMatrix<Field = Self::Field>;
+
+    /// Declaration of the round constant schedule.
+    type RoundConstants: PoseidonRoundConstants<Field = Self::Field>;
+}
+
+/// Zero-sized type describing the 12×12 Poseidon MDS matrix used by the engine.
+#[derive(Debug, Clone, Copy)]
+pub struct PoseidonMdsMatrixV1;
+
+impl PoseidonMdsMatrix for PoseidonMdsMatrixV1 {
+    type Field = FieldElement;
+    const WIDTH: usize = 12;
+}
+
+/// Round-constant descriptor for the Poseidon parameter set.
+#[derive(Debug, Clone, Copy)]
+pub struct PoseidonRoundConstantsV1;
+
+impl PoseidonRoundConstants for PoseidonRoundConstantsV1 {
+    type Field = FieldElement;
+    const FULL_ROUND_COUNT: usize = 8;
+    const PARTIAL_ROUND_COUNT: usize = 56;
+}
+
+/// Parameter specification for the Poseidon permutation with `t = 12`, `rate = 8`,
+/// `capacity = 4`, `\alpha = 5`, `r_f = 8` and `r_p = 56`.
+#[derive(Debug, Clone, Copy)]
+pub struct PoseidonSpecV1;
+
+impl PoseidonPermutationSpec for PoseidonSpecV1 {
+    type Field = FieldElement;
+    const RATE: usize = 8;
+    const CAPACITY: usize = 4;
+    const WIDTH: usize = 12;
+    const ALPHA: u32 = 5;
+    const FULL_ROUNDS: usize = 8;
+    const PARTIAL_ROUNDS: usize = 56;
+    type MdsMatrix = PoseidonMdsMatrixV1;
+    type RoundConstants = PoseidonRoundConstantsV1;
+}
+
+/// Marker trait describing the permutation order applied to the Poseidon state.
+///
+/// The order alternates full rounds and partial rounds as defined by the permutation
+/// specification.  The trait exists purely for documentation so that downstream users
+/// can implement the actual permutation while adhering to the documented sequencing.
+pub trait PoseidonPermutationOrder {
+    /// Number of prefix full rounds executed before partial rounds start.
+    const FULL_ROUNDS_BEFORE_PARTIAL: usize;
+
+    /// Number of partial rounds executed in the middle of the permutation.
+    const PARTIAL_ROUNDS: usize;
+
+    /// Number of suffix full rounds executed after partial rounds complete.
+    const FULL_ROUNDS_AFTER_PARTIAL: usize;
+}
+
+/// Sequencing of Poseidon rounds for the `PoseidonSpecV1` parameter set.
+#[derive(Debug, Clone, Copy)]
+pub struct PoseidonPermutationOrderV1;
+
+impl PoseidonPermutationOrder for PoseidonPermutationOrderV1 {
+    const FULL_ROUNDS_BEFORE_PARTIAL: usize = 4;
+    const PARTIAL_ROUNDS: usize = 56;
+    const FULL_ROUNDS_AFTER_PARTIAL: usize = 4;
 }


### PR DESCRIPTION
## Summary
- replace the Poseidon module with trait-based parameter declarations describing the t=12, rate=8 permutation
- add versioned parameter identifiers and domain tags for Poseidon arithmetic hashes and BLAKE3 transcript commitments
- document the BLAKE3 transcript hasher contract via a dedicated trait and re-export the configuration constants from the hash module

## Testing
- not run (documentation and interface updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e18846ea048326adf8d305b922f602