### PR TITLE
Define transcript layout and randomness interfaces

### DIFF
--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -2,6 +2,7 @@
 //! Provides embedded prover and verifier implementations for the STARK engine.
 
 pub mod prover;
+pub mod transcript;
 pub mod verifier;
 
 pub use prover::Prover;

--- a/src/proof/transcript.rs
+++ b/src/proof/transcript.rs
@@ -1,0 +1,141 @@
+//! Transcript layout description and challenge derivation interfaces.
+//!
+//! The STARK transcript is broken into canonical sections that are serialized
+//! with little-endian length prefixes. Each section is appended as
+//! `len: u32` (little endian) followed by the raw payload bytes. The
+//! transcript begins with the static domain tag `RPP-STARK-V1` which is also
+//! length-prefixed to make the framing self-describing.
+//!
+//! The canonical section order is:
+//! 1. [`TranscriptSectionKind::DomainTag`] – always the static domain tag.
+//! 2. [`TranscriptSectionKind::PublicInputs`] – public witness data.
+//! 3. [`TranscriptSectionKind::CommitmentRoots`] – Merkle roots and FRI commitments.
+//! 4. [`TranscriptSectionKind::ParameterDigest`] – prover/verifier parameter digest.
+//! 5. [`TranscriptSectionKind::BlockContext`] – ambient block metadata.
+//!
+//! Downstream consumers obtain deterministic challenge streams by finalizing
+//! the transcript and deriving [`ChallengeStream`] instances. Implementations
+//! are expected to respect the canonical section ordering and serialization to
+//! ensure interoperability with third-party provers and verifiers.
+//!
+//! ## VRF hooks and neutral seed derivation
+//!
+//! Environments that require publicly verifiable randomness can expose a VRF
+//! output as part of the transcript assembly. The VRF bytes should be
+//! serialized using the same length-prefixed, little-endian framing before
+//! being absorbed into the transcript. Implementations of [`ChallengeDeriver`]
+//! may then derive neutral seeds by mixing the deterministic transcript hash
+//! with the VRF output, ensuring that challenge derivation remains unbiased
+//! while still reproducible for honest parties.
+
+use crate::StarkResult;
+
+/// Domain separation tag for transcript personalization.
+pub const TRANSCRIPT_DOMAIN_TAG: &str = "RPP-STARK-V1";
+
+/// Enumerates the canonical sections of the STARK transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TranscriptSectionKind {
+    /// Domain tag anchoring the transcript serialization.
+    DomainTag,
+    /// Public inputs supplied by the prover.
+    PublicInputs,
+    /// Commitment roots for Merkle/Fri structures.
+    CommitmentRoots,
+    /// Digest of prover/verifier parameters.
+    ParameterDigest,
+    /// Ambient block or execution context data.
+    BlockContext,
+}
+
+impl TranscriptSectionKind {
+    /// Returns the zero-based ordinal of the section in the canonical layout.
+    pub const fn ordinal(self) -> usize {
+        match self {
+            Self::DomainTag => 0,
+            Self::PublicInputs => 1,
+            Self::CommitmentRoots => 2,
+            Self::ParameterDigest => 3,
+            Self::BlockContext => 4,
+        }
+    }
+}
+
+/// Descriptor that couples a [`TranscriptSectionKind`] with its positional index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SectionDescriptor {
+    /// Section identifier.
+    pub kind: TranscriptSectionKind,
+    /// Zero-based index within the transcript layout.
+    pub index: usize,
+}
+
+impl SectionDescriptor {
+    /// Creates a descriptor for a canonical section, automatically deriving the index.
+    pub const fn canonical(kind: TranscriptSectionKind) -> Self {
+        Self {
+            kind,
+            index: kind.ordinal(),
+        }
+    }
+}
+
+/// Canonical layout wrapper for the transcript.
+#[derive(Debug, Clone)]
+pub struct TranscriptLayout {
+    sections: [TranscriptSectionKind; 5],
+}
+
+impl TranscriptLayout {
+    /// Constructs the default layout using the canonical ordering.
+    pub const fn new() -> Self {
+        Self {
+            sections: [
+                TranscriptSectionKind::DomainTag,
+                TranscriptSectionKind::PublicInputs,
+                TranscriptSectionKind::CommitmentRoots,
+                TranscriptSectionKind::ParameterDigest,
+                TranscriptSectionKind::BlockContext,
+            ],
+        }
+    }
+
+    /// Returns the ordered sections as an array reference.
+    pub const fn sections(&self) -> &[TranscriptSectionKind; 5] {
+        &self.sections
+    }
+
+    /// Provides the domain tag bytes used during serialization.
+    pub const fn domain_tag(&self) -> &'static str {
+        TRANSCRIPT_DOMAIN_TAG
+    }
+}
+
+impl Default for TranscriptLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Human-readable label identifying a challenge stream draw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChallengeLabel(pub &'static str);
+
+/// Builder trait that finalizes a transcript into a challenge stream.
+pub trait ChallengeDeriver {
+    /// Concrete challenge stream implementation returned by the builder.
+    type Stream: ChallengeStream;
+
+    /// Finalizes the transcript and produces the challenge stream.
+    fn into_stream(self) -> StarkResult<Self::Stream>;
+}
+
+/// Streaming interface for deterministic challenge extraction.
+pub trait ChallengeStream {
+    /// Fills `output` with challenge bytes associated with `label`.
+    ///
+    /// The produced bytes must be derived solely from the transcript state and
+    /// adhere to the canonical little-endian framing rules described at the
+    /// module level.
+    fn draw_challenge(&mut self, label: ChallengeLabel, output: &mut [u8]) -> StarkResult<()>;
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,5 +4,5 @@
 pub mod randomness;
 pub mod serialization;
 
-pub use randomness::DeterministicRng;
+pub use randomness::{ChallengeStreamExt, TranscriptHook};
 pub use serialization::ProofBytes;

--- a/src/utils/randomness.rs
+++ b/src/utils/randomness.rs
@@ -1,43 +1,52 @@
-//! Deterministic randomness generation based on Blake3 transcripts.
-//! Provides a reproducible RNG for sampling queries and challenges.
+//! Transcript-driven randomness interfaces.
+//!
+//! This module defines abstract traits used by the prover and verifier to
+//! communicate with transcript implementations. The concrete cryptographic
+//! machinery lives outside of this crate; consumers are expected to implement
+//! the traits using their preferred hash functions while adhering to the
+//! canonical serialization rules described in [`crate::proof::transcript`].
 
-use crate::hash::config::Blake3Parameters;
-use crate::hash::Blake3Hasher;
-use crate::{StarkError, StarkResult};
+use crate::proof::transcript::{
+    ChallengeDeriver, ChallengeStream, SectionDescriptor, TranscriptLayout,
+};
+use crate::StarkResult;
 
-/// Deterministic random number generator derived from Blake3.
-#[derive(Debug, Clone)]
-pub struct DeterministicRng {
-    /// Underlying hasher used to produce pseudorandom output.
-    hasher: Blake3Hasher,
-    /// Counter ensuring unique outputs per request.
-    counter: u64,
+/// Hook trait for absorbing transcript sections and deriving deterministic salts.
+pub trait TranscriptHook {
+    /// Type returned once the transcript has been fully absorbed.
+    type Builder: ChallengeDeriver;
+
+    /// Returns the layout the hook is expecting.
+    fn layout(&self) -> &TranscriptLayout;
+
+    /// Absorbs a transcript section and returns the derived `section_salt_i` value.
+    ///
+    /// Implementations must maintain a deterministic chain as specified by the
+    /// STARK transcript design:
+    ///
+    /// ```text
+    /// section_salt_0 = H("RPP-STARK-V1")
+    /// section_salt_i = H(section_salt_{i-1} || len(payload)_LE || payload)
+    /// ```
+    ///
+    /// where `H` denotes the hash primitive selected by the implementer and
+    /// `len(payload)_LE` is a four-byte little-endian length prefix.
+    fn absorb_section(
+        &mut self,
+        descriptor: SectionDescriptor,
+        payload: &[u8],
+    ) -> StarkResult<[u8; 32]>;
+
+    /// Finalizes the transcript and yields a challenge derivation builder.
+    fn finalize(self) -> StarkResult<Self::Builder>;
 }
 
-impl DeterministicRng {
-    /// Creates a new RNG with the provided parameters.
-    pub fn new(params: Blake3Parameters) -> Self {
-        Self {
-            hasher: Blake3Hasher::new(params),
-            counter: 0,
-        }
-    }
-
-    /// Produces the next pseudorandom field element seed as 32 bytes.
-    pub fn next_bytes(&mut self) -> StarkResult<[u8; 32]> {
-        self.counter = self.counter.wrapping_add(1);
-        let mut data = Vec::new();
-        data.extend_from_slice(&self.counter.to_le_bytes());
-        self.hasher.absorb(&data);
-        self.hasher.finalize()
-    }
-
-    /// Reseeds the transcript with deterministic additional data.
-    pub fn reseed(&mut self, seed: &[u8]) -> StarkResult<()> {
-        if seed.is_empty() {
-            return Err(StarkError::InvalidInput("reseed seed cannot be empty"));
-        }
-        self.hasher.absorb(seed);
-        Ok(())
+/// Utility trait allowing implementers to expose a ready-to-use challenge stream.
+pub trait ChallengeStreamExt: ChallengeStream {
+    /// Draws `output` bytes using the provided label, forwarding to the underlying stream.
+    fn draw_bytes(&mut self, label: &'static str, output: &mut [u8]) -> StarkResult<()> {
+        self.draw_challenge(crate::proof::transcript::ChallengeLabel(label), output)
     }
 }
+
+impl<T> ChallengeStreamExt for T where T: ChallengeStream {}


### PR DESCRIPTION
## Summary
- add a dedicated transcript module that documents canonical section ordering, serialization framing, and challenge derivation traits
- replace the previous deterministic RNG struct with transcript hook interfaces and helper utilities for challenge streams
- document how VRF-produced seeds can be incorporated via the transcript module to keep challenge derivation neutral

## Testing
- cargo fmt
- cargo check *(fails: unresolved imports and missing trait implementations in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68e18b8efd448326b83b188bba2cc7eb