### PR TITLE
Document proof interfaces and configs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Core library entry point for the `rpp-stark` proof system.
-//! This module exposes the high-level and low-level APIs for proof generation and verification.
+//! This module exposes the high-level and low-level APIs for proof generation
+//! and verification. All functions are intentionally left without
+//! implementation logic and instead serve as documentation of the intended
+//! interface surface.
 
 pub mod air;
 pub mod config;
@@ -10,8 +13,11 @@ pub mod hash;
 pub mod proof;
 pub mod utils;
 
-use proof::{prover::Prover, verifier::Verifier};
-use utils::serialization::ProofBytes;
+use config::{ProverContext, StarkConfig, VerifierContext};
+use proof::envelope::ProofEnvelope;
+use proof::public_inputs::PublicInputs;
+use proof::{ProofKind, ProofRequest, ProofResponse};
+use utils::serialization::{ProofBytes, WitnessBlob};
 
 /// Result type used throughout the library to surface deterministic errors.
 pub type StarkResult<T> = core::result::Result<T, StarkError>;
@@ -28,13 +34,51 @@ pub enum StarkError {
 }
 
 /// High-level interface for proof generation.
-pub fn generate_proof(context: &config::ProverContext) -> StarkResult<ProofBytes> {
-    let prover = Prover::new(context.clone());
-    prover.create_proof()
+///
+/// The function ties together the documented configuration pieces and passes
+/// them to [`proof::api::generate_proof`]. The return value mirrors the
+/// envelope structure described in the proof module.
+pub fn generate_proof(
+    kind: ProofKind,
+    public_inputs: PublicInputs<'_>,
+    witness: WitnessBlob<'_>,
+    config: &StarkConfig,
+    context: &ProverContext,
+) -> StarkResult<ProofResponse> {
+    let request = ProofRequest {
+        kind,
+        public_inputs,
+        witness,
+        parallelization: context.parallelization,
+        context,
+    };
+    let _ = config;
+    proof::api::generate_proof(request)
 }
 
 /// High-level interface for proof verification.
-pub fn verify_proof(context: &config::VerifierContext, proof: &ProofBytes) -> StarkResult<bool> {
-    let verifier = Verifier::new(context.clone());
-    verifier.verify(proof)
+///
+/// Verifiers pass the expected proof kind, public inputs and envelope plus the
+/// agreed upon context. This stub intentionally forwards into the proof API
+/// without performing any logic.
+pub fn verify_proof(
+    kind: ProofKind,
+    public_inputs: &PublicInputs<'_>,
+    envelope: &ProofEnvelope,
+    config: &StarkConfig,
+    context: &VerifierContext,
+) -> StarkResult<()> {
+    let _ = (config, context);
+    proof::api::verify_proof(kind, public_inputs, envelope, context)
+}
+
+/// Convenience helper for consumers that already assembled a full
+/// [`ProofRequest`].
+pub fn generate_proof_with_request(request: ProofRequest<'_>) -> StarkResult<ProofResponse> {
+    proof::api::generate_proof(request)
+}
+
+/// Convenience helper returning the raw proof bytes from a [`ProofResponse`].
+pub fn extract_proof_bytes(response: &ProofResponse) -> &ProofBytes {
+    &response.bytes
 }

--- a/src/proof/api.rs
+++ b/src/proof/api.rs
@@ -1,0 +1,73 @@
+//! High-level API glue for the proof subsystem.
+//!
+//! This module collects the forward declarations that the public library
+//! surface requires. All items are intentionally free of implementation so
+//! that downstream integrators can plug in their own execution engines while
+//! relying on a stable documentation layer.
+
+use crate::config::{ParallelizationRules, ProverContext, VerifierContext};
+use crate::proof::envelope::ProofEnvelope;
+use crate::proof::public_inputs::{ProofKind, PublicInputs};
+use crate::utils::serialization::{ProofBytes, WitnessBlob};
+use crate::StarkResult;
+
+/// Request object passed to [`generate_proof`].
+///
+/// Each field is described explicitly to make room for additional
+/// instrumentation such as determinism counters or replay guards without
+/// changing the high-level API signature.
+#[derive(Debug, Clone)]
+pub struct ProofRequest<'a> {
+    /// Declares the type of proof that should be produced and which
+    /// header layout applies.
+    pub kind: ProofKind,
+    /// The public inputs for the proof including the header section.
+    pub public_inputs: PublicInputs<'a>,
+    /// Arbitrary witness bytes supplied by the caller. The blob is opaque to
+    /// the documentation layer and is only constrained by the configuration
+    /// object carried in [`ProverContext`].
+    pub witness: WitnessBlob<'a>,
+    /// Parallelisation parameters negotiated between caller and runtime.
+    pub parallelization: ParallelizationRules,
+    /// Optional protocol specific configuration. This is a passive reference
+    /// into the user provided context to avoid unnecessary cloning.
+    pub context: &'a ProverContext,
+}
+
+/// Response object produced by [`generate_proof`].
+#[derive(Debug, Clone)]
+pub struct ProofResponse {
+    /// Full envelope containing versioned metadata and the proof body.
+    pub envelope: ProofEnvelope,
+    /// Raw proof bytes that may be streamed or cached.
+    pub bytes: ProofBytes,
+}
+
+/// High-level proof generation entry point.
+///
+/// The documentation specifies the intended call flow:
+/// - Choose a [`ProofKind`].
+/// - Assemble [`PublicInputs`] matching the declared header layout.
+/// - Provide witness data in a [`WitnessBlob`].
+/// - Reuse the configured [`ProverContext`] alongside negotiated
+///   [`ParallelizationRules`].
+///
+/// The implementation is intentionally left unspecified.
+pub fn generate_proof(_request: ProofRequest<'_>) -> StarkResult<ProofResponse> {
+    unimplemented!("interface declaration only")
+}
+
+/// High-level proof verification entry point.
+///
+/// Consumers supply the [`ProofKind`] they expect, the authoritative public
+/// inputs and the envelope returned by [`generate_proof`]. The verifier
+/// context is kept separate to highlight that VRF sampling and transcript
+/// binding can be evolved independently from the prover configuration.
+pub fn verify_proof(
+    _kind: ProofKind,
+    _public_inputs: &PublicInputs<'_>,
+    _envelope: &ProofEnvelope,
+    _context: &VerifierContext,
+) -> StarkResult<()> {
+    unimplemented!("interface declaration only")
+}

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -1,0 +1,59 @@
+//! Proof envelope describing versioning and integrity layout.
+//!
+//! The envelope is the canonical container that wraps every proof byte stream
+//! produced by the system. It ensures that verifiers can reason about the
+//! version, the declared proof kind, the length of both header and body, and
+//! the integrity digest without parsing custom metadata formats.
+
+use crate::proof::public_inputs::ProofKind;
+use crate::utils::serialization::DigestBytes;
+
+/// Maximum allowed size for a proof including envelope metadata.
+pub const MAX_PROOF_SIZE_BYTES: usize = 32 * 1024 * 1024;
+
+/// Enumerates the current envelope format versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvelopeVersion {
+    /// Initial format using fixed width little endian counters.
+    V1,
+}
+
+/// Header written ahead of the proof body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofEnvelopeHeader {
+    /// Version of the envelope layout.
+    pub version: EnvelopeVersion,
+    /// Declared proof kind. Mirrors the header layout chosen for the
+    /// public inputs.
+    pub kind: ProofKind,
+    /// Length of the serialized header segment that follows this struct.
+    pub header_length: u32,
+    /// Length of the serialized body.
+    pub body_length: u32,
+    /// Digest binding the header and body for integrity checks.
+    pub integrity_digest: DigestBytes,
+}
+
+impl ProofEnvelopeHeader {
+    /// Returns the total declared payload length (header + body).
+    pub fn total_payload_length(&self) -> u64 {
+        self.header_length as u64 + self.body_length as u64
+    }
+}
+
+/// Envelope containing header metadata and the proof body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofEnvelope {
+    /// Structured metadata describing the proof stream.
+    pub header: ProofEnvelopeHeader,
+    /// Raw proof bytes following the header.
+    pub body: Vec<u8>,
+}
+
+impl ProofEnvelope {
+    /// Creates a new envelope and performs basic boundary documentation.
+    pub fn new(header: ProofEnvelopeHeader, body: Vec<u8>) -> Self {
+        debug_assert!(body.len() <= MAX_PROOF_SIZE_BYTES);
+        Self { header, body }
+    }
+}

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -1,9 +1,15 @@
 //! Proof generation and verification subsystem.
-//! Provides embedded prover and verifier implementations for the STARK engine.
+//! Provides embedded prover and verifier interfaces for the STARK engine.
 
+pub mod api;
+pub mod envelope;
 pub mod prover;
+pub mod public_inputs;
 pub mod transcript;
 pub mod verifier;
 
+pub use api::{generate_proof, verify_proof, ProofRequest, ProofResponse};
+pub use envelope::{ProofEnvelope, ProofEnvelopeHeader};
 pub use prover::Prover;
+pub use public_inputs::{ProofKind, PublicInputs};
 pub use verifier::Verifier;

--- a/src/proof/public_inputs.rs
+++ b/src/proof/public_inputs.rs
@@ -1,0 +1,102 @@
+//! Declarative description of public input layouts per proof kind.
+//!
+//! The goal of this module is to document, rather than implement, how public
+//! inputs are structured across the different proof categories supported by
+//! the STARK engine. Each structure captures the versioned header fields that
+//! must be present before any proof specific body is interpreted.
+
+use crate::utils::serialization::{DigestBytes, FieldElementBytes};
+
+/// Enumerates all supported proof kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofKind {
+    /// Proves a single execution trace.
+    Execution,
+    /// Aggregates multiple execution proofs into a compressed certificate.
+    Aggregation,
+    /// Wraps recursion layers for rollup scenarios.
+    Recursion,
+}
+
+/// Version tag for public input headers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicInputVersion {
+    /// First stable version of the documentation.
+    V1,
+}
+
+/// Public input header for execution proofs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionHeaderV1 {
+    /// Version of the header format.
+    pub version: PublicInputVersion,
+    /// Hash of the program being executed.
+    pub program_digest: DigestBytes,
+    /// Length of the execution trace in field elements.
+    pub trace_length: u32,
+    /// Selector indicating if the trace is padded.
+    pub padded: bool,
+}
+
+/// Public input header for aggregation proofs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregationHeaderV1 {
+    /// Version of the header format.
+    pub version: PublicInputVersion,
+    /// Digest of the aggregation circuit definition.
+    pub circuit_digest: DigestBytes,
+    /// Number of included leaf proofs.
+    pub leaf_count: u32,
+    /// Commitment to the root of the aggregation tree.
+    pub root_digest: DigestBytes,
+}
+
+/// Public input header for recursion proofs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecursionHeaderV1 {
+    /// Version of the header format.
+    pub version: PublicInputVersion,
+    /// Depth of the recursion stack.
+    pub depth: u8,
+    /// Digest binding the recursion boundary values.
+    pub boundary_digest: DigestBytes,
+    /// Field element that seeds the recursive verifier context.
+    pub recursion_seed: FieldElementBytes,
+}
+
+/// Unified container for public inputs across proof kinds.
+#[derive(Debug, Clone)]
+pub enum PublicInputs<'a> {
+    /// Execution proof layout.
+    Execution {
+        /// Header metadata.
+        header: ExecutionHeaderV1,
+        /// Body bytes (application specific data).
+        body: &'a [u8],
+    },
+    /// Aggregation proof layout.
+    Aggregation {
+        /// Header metadata.
+        header: AggregationHeaderV1,
+        /// Serialized accumulator witnesses.
+        body: &'a [u8],
+    },
+    /// Recursion proof layout.
+    Recursion {
+        /// Header metadata.
+        header: RecursionHeaderV1,
+        /// Serialized recursion stack body.
+        body: &'a [u8],
+    },
+}
+
+impl<'a> PublicInputs<'a> {
+    /// Returns the declared proof kind for these public inputs.
+    pub fn kind(&self) -> ProofKind {
+        match self {
+            Self::Execution { .. } => ProofKind::Execution,
+            Self::Aggregation { .. } => ProofKind::Aggregation,
+            Self::Recursion { .. } => ProofKind::Recursion,
+        }
+    }
+}

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -1,43 +1,47 @@
-//! Verifier implementation for the `rpp-stark` engine.
-//! Performs deterministic checks over provided proofs.
+//! Verifier interface for the `rpp-stark` engine.
+//!
+//! The verifier consumes proof envelopes and replays the transcript checks in a
+//! deterministic manner. This module documents the expected interface and the
+//! VRF decoupling points without providing an actual implementation.
 
 use crate::config::VerifierContext;
-use crate::fri::{FriBatch, FriBatchVerificationApi, FriProof};
-use crate::hash::Blake3Hasher;
-use crate::utils::serialization::ProofBytes;
-use crate::{StarkError, StarkResult};
+use crate::proof::envelope::ProofEnvelope;
+use crate::proof::public_inputs::PublicInputs;
+use crate::utils::serialization::DigestBytes;
+use crate::StarkResult;
 
 /// Verifier struct encapsulating deterministic verification logic.
 #[derive(Debug, Clone)]
-pub struct Verifier {
+pub struct Verifier<'ctx> {
     /// Context containing configuration parameters.
-    pub context: VerifierContext,
+    pub context: &'ctx VerifierContext,
 }
 
-impl Verifier {
+impl<'ctx> Verifier<'ctx> {
     /// Constructs a new verifier.
-    pub fn new(context: VerifierContext) -> Self {
+    pub fn new(context: &'ctx VerifierContext) -> Self {
         Self { context }
     }
 
-    /// Verifies the provided proof bytes against the context.
-    pub fn verify(&self, proof: &ProofBytes) -> StarkResult<bool> {
-        if proof.as_slice().is_empty() {
-            return Err(StarkError::InvalidInput("proof bytes cannot be empty"));
-        }
-        let fri_proof = FriProof::default();
-        let batch = FriBatch {
-            proofs: vec![fri_proof],
-            ..FriBatch::default()
-        };
-        // Assert access to the declarative API that will be consumed by the real verifier.
-        let _ = (
-            batch.proofs().len(),
-            batch.query_positions().len(),
-            batch.aggregate_digest().bytes,
-        );
-        let mut hasher = Blake3Hasher::new(self.context.stark.hash.blake3.clone());
-        let digest = hasher.hash(proof.as_slice())?;
-        Ok(digest[0] & 1 == 0)
+    /// Verifies the provided proof envelope against the context.
+    ///
+    /// Verification is expected to perform the following steps:
+    /// - Check the envelope header against the documented [`PublicInputs`]
+    ///   layout.
+    /// - Recompute transcript digests according to the security goals and
+    ///   confirm they match the declared integrity digest.
+    /// - Derive VRF challenges locally, using the commitments embedded in the
+    ///   proof envelope without round-tripping to the prover.
+    pub fn verify(
+        &self,
+        _public_inputs: &PublicInputs<'_>,
+        _envelope: &ProofEnvelope,
+    ) -> StarkResult<()> {
+        unimplemented!("interface declaration only")
+    }
+
+    /// Extracts VRF commitments from the envelope for external auditors.
+    pub fn vrf_commitments(_envelope: &ProofEnvelope) -> StarkResult<DigestBytes> {
+        unimplemented!("interface declaration only")
     }
 }

--- a/src/utils/serialization.rs
+++ b/src/utils/serialization.rs
@@ -1,5 +1,9 @@
 //! Serialization utilities for proofs and transcripts.
-//! Provides deterministic byte representations for cross-component communication.
+//!
+//! The types in this module model the byte-level representation of the
+//! proof interface. They are intentionally thin wrappers around byte slices
+//! but come with extensive documentation that mirrors the constraints imposed
+//! by the proof formats documented elsewhere.
 
 /// Wrapper around proof bytes ensuring explicit conversions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,4 +22,25 @@ impl ProofBytes {
     pub fn as_slice(&self) -> &[u8] {
         &self.bytes
     }
+}
+
+/// Opaque wrapper representing a byte encoded witness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitnessBlob<'a> {
+    /// Borrowed witness bytes provided by the caller.
+    pub bytes: &'a [u8],
+}
+
+/// Fixed width digest byte array used throughout the documentation layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DigestBytes {
+    /// Raw digest bytes (e.g. BLAKE3, SHA-256 etc.).
+    pub bytes: [u8; 32],
+}
+
+/// Wrapper around field element encodings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldElementBytes {
+    /// Little endian encoding of a field element.
+    pub bytes: [u8; 32],
 }

--- a/tests/spec.md
+++ b/tests/spec.md
@@ -1,0 +1,27 @@
+# Prover/Verifier Determinism Specification
+
+This repository currently ships interface-only modules. Implementations are
+expected to satisfy the following behavioural contracts once wired in:
+
+## Deterministic Proving
+- `generate_proof` must be deterministic for a fixed combination of
+  `ProofKind`, public inputs, witness blob and `ProverContext`.
+- VRF commitments embedded inside the `ProofEnvelope` must be derived solely
+  from prover-side state; no verifier challenge is allowed during the
+  generation phase.
+
+## Envelope and Size Checks
+- Every produced `ProofEnvelope` must respect `MAX_PROOF_SIZE_BYTES` including
+  metadata and body payload.
+- Header lengths must match the serialized payload lengths documented in
+  `public_inputs.rs` and the integrity digest must bind both segments.
+
+## Verifier Requirements
+- `Verifier::verify` must recompute transcript digests locally and compare
+  them against the envelope without relying on prover responses.
+- VRF challenges must be derived by the verifier independently using the
+  commitments extracted via `Verifier::vrf_commitments`.
+
+Test harnesses should capture these invariants through reproducible fixtures
+that assert byte-for-byte equality of proof outputs and verify the maximum
+size constraints.


### PR DESCRIPTION
## Summary
- add documentation-only modules describing proof public inputs, envelope layout and API requests
- restate configuration, serialization and high-level library functions as interface stubs with extensive doc comments
- document prover/verifier VRF decoupling interfaces and record determinism requirements in tests/spec.md

## Testing
- not run (documentation and interface declarations only)


------
https://chatgpt.com/codex/tasks/task_e_68e18dc3c41c8326a98a47f5d7a4a4da