### PR TITLE
Document canonical configuration profiles and digests

### DIFF
--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -72,7 +72,7 @@ impl<'ctx> VerifierContextUsage<'ctx> {
     pub fn new(context: &'ctx VerifierContext) -> Self {
         Self {
             context,
-            limits: context.limits,
+            limits: context.limits.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- rebuild the config module with canonical identifiers, domain tags, proof-kind ordering, and ParamDigest/PI-digest documentation
- add standard, high-security, and high-throughput profile descriptors with resource limits plus change-control and test guidance
- update verifier context usage to clone limits now that ResourceLimits is non-Copy

## Testing
- cargo check *(fails: pre-existing lifetime and digest length errors in fft::Radix2GeneratorTable and hash::merkle)*

------
https://chatgpt.com/codex/tasks/task_e_68e198a27170832689fafe8299555ac0