### PR TITLE
Add deterministic FFT and LDE regression tests

### DIFF
--- a/tests/fft.rs
+++ b/tests/fft.rs
@@ -1,0 +1,63 @@
+use blake3::Hasher;
+
+use rpp_stark::fft::ifft::{Ifft, Radix2InverseFft};
+use rpp_stark::fft::{Fft, Radix2Fft, Radix2Ordering};
+use rpp_stark::field::FieldElement;
+
+fn deterministic_field_vector(len: usize) -> Vec<FieldElement> {
+    let mut state = 0x9e3779b97f4a7c15u64;
+    (0..len)
+        .map(|_| {
+            state = state
+                .wrapping_mul(0x5851f42d4c957f2d)
+                .wrapping_add(0x14057b7ef767814f);
+            FieldElement::from(state)
+        })
+        .collect()
+}
+
+fn to_montgomery(value: FieldElement) -> FieldElement {
+    let modulus = FieldElement::MODULUS.value as u128;
+    let r = FieldElement::R as u128;
+    let product = (value.0 as u128 * r) % modulus;
+    FieldElement::from(product as u64)
+}
+
+fn digest_table(entries: &[FieldElement]) -> String {
+    let mut hasher = Hasher::new();
+    for value in entries.iter() {
+        hasher.update(&value.0.to_le_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+#[test]
+fn radix2_fft_roundtrip_preserves_inputs() {
+    let log2_size = 6;
+    let size = 1usize << log2_size;
+
+    let canonical = deterministic_field_vector(size);
+    let mut montgomery: Vec<FieldElement> = canonical.iter().copied().map(to_montgomery).collect();
+    let original = montgomery.clone();
+
+    let forward = Radix2Fft::new(log2_size, Radix2Ordering::Natural);
+    forward.forward(&mut montgomery);
+
+    let inverse = Radix2InverseFft::new(log2_size, Radix2Ordering::Natural);
+    inverse.inverse(&mut montgomery);
+
+    assert_eq!(montgomery, original, "IFFT(FFT(v)) must recover the input vector");
+}
+
+#[test]
+fn radix2_twiddle_tables_digest_is_stable() {
+    let log2_size = 8;
+    let plan = Radix2Fft::natural_order(log2_size);
+    let forward_digest = digest_table(plan.domain().generators.forward);
+    let inverse_digest = digest_table(plan.domain().generators.inverse);
+
+    // Audited digests for the Montgomery-encoded radix-2 roots of unity.
+    // Update only if the deterministic seed or root derivation changes.
+    assert_eq!(forward_digest, "5d72ab04a814b762a49b4bba30aaf50b7d8ece41c5ccb28e578306353028be1c");
+    assert_eq!(inverse_digest, "271e22d610b8a657df9a3d5204b645a8af3e04718663b61649f693f3d0d26fa3");
+}

--- a/tests/lde.rs
+++ b/tests/lde.rs
@@ -1,0 +1,113 @@
+use rpp_stark::fft::lde::{LdeChunk, LowDegreeExtender, PROFILE_HISEC_X16, PROFILE_X8};
+use rpp_stark::field::FieldElement;
+
+fn deterministic_trace(rows: usize, cols: usize) -> Vec<FieldElement> {
+    let mut state = 0xd1b54a32d192ed03u64;
+    let mut trace = Vec::with_capacity(rows * cols);
+    for _ in 0..rows * cols {
+        state = state
+            .wrapping_mul(0x94d049bb133111eb)
+            .wrapping_add(0xda942042e4dd58b5);
+        trace.push(to_montgomery(FieldElement::from(state)));
+    }
+    trace
+}
+
+fn bit_reverse(value: usize, bits: usize) -> usize {
+    if bits == 0 {
+        value
+    } else {
+        value.reverse_bits() >> (usize::BITS as usize - bits)
+    }
+}
+
+fn to_montgomery(value: FieldElement) -> FieldElement {
+    let modulus = FieldElement::MODULUS.value as u128;
+    let r = FieldElement::R as u128;
+    let product = (value.0 as u128 * r) % modulus;
+    FieldElement::from(product as u64)
+}
+
+#[test]
+fn x8_extender_shape_and_ordering() {
+    let trace_rows = 4;
+    let trace_cols = 3;
+    let trace = deterministic_trace(trace_rows, trace_cols);
+
+    let extender = LowDegreeExtender::new(trace_rows, trace_cols, &PROFILE_X8);
+    let extended = extender.extend_trace(&trace);
+
+    assert_eq!(extended.len(), extender.extended_rows() * trace_cols);
+
+    for natural_row in 0..extender.extended_rows() {
+        let expected_bucket = bit_reverse(natural_row, extender.log2_extended_rows());
+        for column in 0..trace_cols {
+            let index = extender.lde_index(natural_row, column);
+            assert_eq!(index / trace_cols, expected_bucket);
+        }
+    }
+}
+
+#[test]
+fn x16_extender_shape_and_ordering() {
+    let trace_rows = 2;
+    let trace_cols = 2;
+    let trace = deterministic_trace(trace_rows, trace_cols);
+
+    let extender = LowDegreeExtender::new(trace_rows, trace_cols, &PROFILE_HISEC_X16);
+    let extended = extender.extend_trace(&trace);
+
+    assert_eq!(extended.len(), extender.extended_rows() * trace_cols);
+
+    for natural_row in 0..extender.extended_rows() {
+        for column in 0..trace_cols {
+            let index = extender.lde_index(natural_row, column);
+            assert_eq!(index, column * extender.extended_rows() + natural_row);
+        }
+    }
+}
+
+fn verify_chunk_invariance(extender: &LowDegreeExtender, baseline: &[FieldElement]) {
+    let rows = extender.extended_rows();
+    let cols = extender.trace_columns();
+    let baseline_chunks: Vec<LdeChunk> = extender.chunk_iter(0, 1).collect();
+
+    for workers in 1..=4 {
+        let mut assembled = vec![FieldElement::ZERO; baseline.len()];
+        let mut covered_rows = vec![false; rows];
+        let mut combined: Vec<LdeChunk> = Vec::new();
+
+        for worker_id in 0..workers {
+            for chunk in extender.chunk_iter(worker_id, workers) {
+                combined.push(chunk);
+                for natural_row in chunk.start_row..chunk.end_row {
+                    covered_rows[natural_row] = true;
+                    for column in 0..cols {
+                        let index = extender.lde_index(natural_row, column);
+                        assembled[index] = baseline[index];
+                    }
+                }
+            }
+        }
+
+        combined.sort_by_key(|chunk| chunk.start_row);
+        assert_eq!(combined, baseline_chunks);
+        assert!(covered_rows.into_iter().all(|covered| covered));
+        assert_eq!(assembled, baseline);
+    }
+}
+
+#[test]
+fn deterministic_chunking_is_worker_invariant() {
+    let trace_rows = 4;
+    let trace_cols = 2;
+    let trace = deterministic_trace(trace_rows, trace_cols);
+
+    let extender_x8 = LowDegreeExtender::new(trace_rows, trace_cols, &PROFILE_X8);
+    let baseline_x8 = extender_x8.extend_trace(&trace);
+    verify_chunk_invariance(&extender_x8, &baseline_x8);
+
+    let extender_x16 = LowDegreeExtender::new(trace_rows, trace_cols, &PROFILE_HISEC_X16);
+    let baseline_x16 = extender_x16.extend_trace(&trace);
+    verify_chunk_invariance(&extender_x16, &baseline_x16);
+}


### PR DESCRIPTION
## Summary
- add FFT integration tests covering deterministic round-trips and twiddle digests
- introduce LDE tests validating x8/x16 extender sizing, ordering, and chunk determinism

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e201f3c0b88326b7614fcd37c4f015