### PR TITLE
Add lint gates and enforce them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  rust:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Cargo build
+        run: cargo build --locked
+      - name: Cargo test
+        run: cargo test -p rpp-stark -- --nocapture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
 //! Core library entry point for the `rpp-stark` proof system.
 //!
 //! The crate exposes declarative contracts for proof generation, verification


### PR DESCRIPTION
## Summary
- deny `unsafe_code` and `rust_2018_idioms` at the crate level
- add a CI workflow to run the locked build and package tests so the lint gates stay enforced

## Testing
- cargo build --locked
- cargo test -p rpp-stark -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e27d706b8c832690313a78dad04070