### PR TITLE
Refactor FRI types into shared module

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -8,7 +8,7 @@ use rpp_stark::config::{
     PROFILE_STD, PROFILE_THROUGHPUT_CONFIG,
 };
 use rpp_stark::field::FieldElement;
-use rpp_stark::fri::{FriProof, FriSecurityLevel};
+use rpp_stark::fri::types::{FriProof, FriSecurityLevel};
 use rpp_stark::hash::{hash, Hasher, OutputReader};
 use rpp_stark::proof::envelope::{
     compute_commitment_digest, compute_integrity_digest, serialize_public_inputs,

--- a/src/fri/batch.rs
+++ b/src/fri/batch.rs
@@ -7,8 +7,9 @@
 
 use crate::field::FieldElement;
 
-use super::proof::{FriError, FriProof, FriSecurityLevel, FriTranscriptSeed, FriVerifier};
+use super::proof::FriVerifier;
 use super::pseudo_blake3;
+use super::types::{FriError, FriProof, FriSecurityLevel, FriTranscriptSeed};
 
 /// Seed shared across the batch, typically derived from a transcript challenge.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -11,13 +11,15 @@ mod batch;
 pub mod config;
 mod folding;
 mod proof;
+pub mod types;
 
 pub(crate) use crate::hash::{pseudo_blake3, PseudoBlake3Xof};
 pub use batch::{BatchDigest, BatchQueryPosition, BatchSeed, FriBatch, FriBatchVerificationApi};
 pub use folding::{quartic_fold, FoldingLayer, FoldingLayout, LayerCommitment, QUARTIC_FOLD};
-pub use proof::{
-    derive_query_plan_id, FriError, FriProof, FriQuery, FriQueryLayer, FriSecurityLevel,
-    FriTranscriptSeed, FriVerifier,
+pub use proof::{derive_query_plan_id, FriVerifier};
+pub use types::{
+    FriError, FriParamsView, FriProof, FriProofVersion, FriQuery, FriQueryLayer, FriSecurityLevel,
+    FriTranscriptSeed, SerKind,
 };
 
 use crate::field::FieldElement;

--- a/src/fri/proof.rs
+++ b/src/fri/proof.rs
@@ -7,6 +7,9 @@
 
 use crate::field::FieldElement;
 use crate::fri::folding::{quartic_fold, QUARTIC_FOLD};
+use crate::fri::types::{
+    FriError, FriProof, FriQuery, FriQueryLayer, FriSecurityLevel, FriTranscriptSeed,
+};
 use crate::fri::{
     field_from_hash, field_to_bytes, hash_internal, hash_leaf, pseudo_blake3, PseudoBlake3Xof,
 };
@@ -14,84 +17,6 @@ use crate::hash::blake3::FiatShamirChallengeRules;
 use crate::hash::merkle::{
     compute_root_from_path, encode_leaf, MerkleError, MerkleIndex, MerklePathElement, EMPTY_DIGEST,
 };
-use core::fmt;
-
-/// Transcript seed used when instantiating the FRI prover and verifier.
-pub type FriTranscriptSeed = [u8; 32];
-
-/// Security profiles supported by the FRI engine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FriSecurityLevel {
-    /// Standard profile with 64 queries.
-    Standard,
-    /// High security profile with 96 queries.
-    HiSec,
-    /// Throughput oriented profile with 48 queries.
-    Throughput,
-}
-
-impl FriSecurityLevel {
-    /// Returns the query budget associated with the profile.
-    pub const fn query_budget(self) -> usize {
-        match self {
-            FriSecurityLevel::Standard => 64,
-            FriSecurityLevel::HiSec => 96,
-            FriSecurityLevel::Throughput => 48,
-        }
-    }
-
-    fn tag(self) -> &'static str {
-        match self {
-            FriSecurityLevel::Standard => "STD",
-            FriSecurityLevel::HiSec => "HISEC",
-            FriSecurityLevel::Throughput => "THR",
-        }
-    }
-}
-
-/// FRI verification errors mapped to the specification failure classes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FriError {
-    /// No evaluations were provided to the prover.
-    EmptyCodeword,
-    /// Query position exceeded the LDE domain size.
-    QueryOutOfRange { position: usize },
-    /// Merkle path was malformed (index byte mismatch or inconsistent height).
-    PathInvalid { layer: usize, reason: MerkleError },
-    /// Merkle layer root mismatch.
-    LayerRootMismatch { layer: usize },
-    /// Proof declared a different security profile.
-    SecurityLevelMismatch,
-    /// Proof declared an unexpected number of queries.
-    QueryBudgetMismatch { expected: usize, actual: usize },
-    /// Generic structure error (missing layer, inconsistent lengths, etc.).
-    InvalidStructure(&'static str),
-}
-
-impl fmt::Display for FriError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FriError::EmptyCodeword => write!(f, "codeword is empty"),
-            FriError::QueryOutOfRange { position } => {
-                write!(f, "query position {position} outside evaluation domain")
-            }
-            FriError::PathInvalid { layer, reason } => {
-                write!(f, "invalid Merkle path at layer {layer}: {reason}")
-            }
-            FriError::LayerRootMismatch { layer } => {
-                write!(f, "layer {layer} root mismatch")
-            }
-            FriError::SecurityLevelMismatch => write!(f, "security profile mismatch"),
-            FriError::QueryBudgetMismatch { expected, actual } => write!(
-                f,
-                "query budget mismatch (expected {expected}, got {actual})"
-            ),
-            FriError::InvalidStructure(reason) => write!(f, "invalid proof structure: {reason}"),
-        }
-    }
-}
-
-impl std::error::Error for FriError {}
 
 /// Helper struct representing a prover transcript.
 #[derive(Debug, Clone)]
@@ -221,43 +146,6 @@ fn hash_final_layer(values: &[FieldElement]) -> [u8; 32] {
         payload.extend_from_slice(&field_to_bytes(value));
     }
     pseudo_blake3(&payload)
-}
-
-/// Declarative representation of a single query opening.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FriQuery {
-    /// Position sampled from the LDE domain.
-    pub position: usize,
-    /// Layer openings ascending from the original codeword to the residual layer.
-    pub layers: Vec<FriQueryLayer>,
-    /// Value revealed at the residual polynomial for this query.
-    pub final_value: FieldElement,
-}
-
-/// Opening data for a specific FRI layer.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FriQueryLayer {
-    /// Evaluation revealed at this layer.
-    pub value: FieldElement,
-    /// Merkle authentication path proving membership.
-    pub path: Vec<MerklePathElement>,
-}
-
-/// Declarative representation of a FRI proof.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FriProof {
-    /// Declared security profile for the proof.
-    pub security_level: FriSecurityLevel,
-    /// Size of the initial evaluation domain.
-    pub initial_domain_size: usize,
-    /// Merkle roots for each folded layer.
-    pub layer_roots: Vec<[u8; 32]>,
-    /// Residual polynomial evaluations.
-    pub final_polynomial: Vec<FieldElement>,
-    /// Digest binding the final polynomial values.
-    pub final_polynomial_digest: [u8; 32],
-    /// Query openings.
-    pub queries: Vec<FriQuery>,
 }
 
 /// Maximum degree allowed for the residual polynomial.

--- a/src/fri/types.rs
+++ b/src/fri/types.rs
@@ -1,0 +1,213 @@
+use core::fmt;
+
+use crate::field::FieldElement;
+use crate::hash::merkle::{MerkleError, MerklePathElement};
+
+/// Transcript seed used when instantiating the FRI prover and verifier.
+pub type FriTranscriptSeed = [u8; 32];
+
+/// Security profiles supported by the FRI engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FriSecurityLevel {
+    /// Standard profile with 64 queries.
+    Standard,
+    /// High security profile with 96 queries.
+    HiSec,
+    /// Throughput oriented profile with 48 queries.
+    Throughput,
+}
+
+impl FriSecurityLevel {
+    /// Returns the query budget associated with the profile.
+    pub const fn query_budget(self) -> usize {
+        match self {
+            FriSecurityLevel::Standard => 64,
+            FriSecurityLevel::HiSec => 96,
+            FriSecurityLevel::Throughput => 48,
+        }
+    }
+
+    pub(crate) fn tag(self) -> &'static str {
+        match self {
+            FriSecurityLevel::Standard => "STD",
+            FriSecurityLevel::HiSec => "HISEC",
+            FriSecurityLevel::Throughput => "THR",
+        }
+    }
+}
+
+/// Version tag attached to FRI proofs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FriProofVersion {
+    /// Initial version of the quartic FRI proof format.
+    V1,
+}
+
+impl FriProofVersion {
+    /// Latest supported proof version.
+    pub const CURRENT: FriProofVersion = FriProofVersion::V1;
+}
+
+/// Kind markers used when reporting serialization errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SerKind {
+    /// Parameters payload framing.
+    Params,
+    /// Proof body framing.
+    Proof,
+    /// Query openings payload framing.
+    Query,
+    /// Layer openings payload framing.
+    Layer,
+    /// Final polynomial encoding.
+    FinalPolynomial,
+}
+
+impl fmt::Display for SerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SerKind::Params => write!(f, "parameters"),
+            SerKind::Proof => write!(f, "proof"),
+            SerKind::Query => write!(f, "query"),
+            SerKind::Layer => write!(f, "layer"),
+            SerKind::FinalPolynomial => write!(f, "final polynomial"),
+        }
+    }
+}
+
+/// FRI verification errors mapped to the specification failure classes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FriError {
+    /// Proof version mismatch.
+    VersionMismatch {
+        /// Expected proof version for the verifier.
+        expected: FriProofVersion,
+        /// Version declared by the proof being processed.
+        actual: FriProofVersion,
+    },
+    /// Folding constraints were violated during verification.
+    FoldingConstraintViolated {
+        /// Layer index where the folding constraint failed.
+        layer: usize,
+    },
+    /// Out-of-domain sampling failed.
+    OodsInvalid,
+    /// Serialization failure when decoding proof artefacts.
+    Serialization(SerKind),
+    /// No evaluations were provided to the prover.
+    EmptyCodeword,
+    /// Query position exceeded the LDE domain size.
+    QueryOutOfRange {
+        /// Position outside the evaluation domain.
+        position: usize,
+    },
+    /// Merkle path was malformed (index byte mismatch or inconsistent height).
+    PathInvalid {
+        /// Layer where the invalid path was detected.
+        layer: usize,
+        /// Underlying Merkle verification error.
+        reason: MerkleError,
+    },
+    /// Merkle layer root mismatch.
+    LayerRootMismatch {
+        /// Layer index that produced a different root.
+        layer: usize,
+    },
+    /// Proof declared a different security profile.
+    SecurityLevelMismatch,
+    /// Proof declared an unexpected number of queries.
+    QueryBudgetMismatch {
+        /// Expected number of queries for the security profile.
+        expected: usize,
+        /// Actual number of queries provided by the proof.
+        actual: usize,
+    },
+    /// Generic structure error (missing layer, inconsistent lengths, etc.).
+    InvalidStructure(&'static str),
+}
+
+impl fmt::Display for FriError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FriError::VersionMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "proof version mismatch (expected {expected:?}, got {actual:?})"
+                )
+            }
+            FriError::FoldingConstraintViolated { layer } => {
+                write!(f, "folding constraint violated at layer {layer}")
+            }
+            FriError::OodsInvalid => write!(f, "out-of-domain sampling constraint failed"),
+            FriError::Serialization(kind) => {
+                write!(f, "failed to serialize/deserialize FRI {kind}")
+            }
+            FriError::EmptyCodeword => write!(f, "codeword is empty"),
+            FriError::QueryOutOfRange { position } => {
+                write!(f, "query position {position} outside evaluation domain")
+            }
+            FriError::PathInvalid { layer, reason } => {
+                write!(f, "invalid Merkle path at layer {layer}: {reason}")
+            }
+            FriError::LayerRootMismatch { layer } => {
+                write!(f, "layer {layer} root mismatch")
+            }
+            FriError::SecurityLevelMismatch => write!(f, "security profile mismatch"),
+            FriError::QueryBudgetMismatch { expected, actual } => write!(
+                f,
+                "query budget mismatch (expected {expected}, got {actual})"
+            ),
+            FriError::InvalidStructure(reason) => write!(f, "invalid proof structure: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for FriError {}
+
+/// Declarative representation of a single query opening.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FriQuery {
+    /// Position sampled from the LDE domain.
+    pub position: usize,
+    /// Layer openings ascending from the original codeword to the residual layer.
+    pub layers: Vec<FriQueryLayer>,
+    /// Value revealed at the residual polynomial for this query.
+    pub final_value: FieldElement,
+}
+
+/// Opening data for a specific FRI layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FriQueryLayer {
+    /// Evaluation revealed at this layer.
+    pub value: FieldElement,
+    /// Merkle authentication path proving membership.
+    pub path: Vec<MerklePathElement>,
+}
+
+/// Declarative representation of a FRI proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FriProof {
+    /// Declared security profile for the proof.
+    pub security_level: FriSecurityLevel,
+    /// Size of the initial evaluation domain.
+    pub initial_domain_size: usize,
+    /// Merkle roots for each folded layer.
+    pub layer_roots: Vec<[u8; 32]>,
+    /// Residual polynomial evaluations.
+    pub final_polynomial: Vec<FieldElement>,
+    /// Digest binding the final polynomial values.
+    pub final_polynomial_digest: [u8; 32],
+    /// Query openings.
+    pub queries: Vec<FriQuery>,
+}
+
+/// Borrowed view over the parameters required when verifying a proof.
+#[derive(Debug, Clone, Copy)]
+pub struct FriParamsView<'a> {
+    /// Declared proof version.
+    pub version: FriProofVersion,
+    /// Security profile used for the proof.
+    pub security_level: FriSecurityLevel,
+    /// Query plan identifier derived from the security level.
+    pub query_plan: &'a [u8; 32],
+}

--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -362,8 +362,8 @@ mod tests {
                     aux_root: [0u8; 32],
                     fri_layer_roots: Vec::new(),
                     ood_openings: Vec::new(),
-                    fri_proof: crate::fri::FriProof {
-                        security_level: crate::fri::FriSecurityLevel::Standard,
+                    fri_proof: crate::fri::types::FriProof {
+                        security_level: crate::fri::types::FriSecurityLevel::Standard,
                         initial_domain_size: 1,
                         layer_roots: Vec::new(),
                         final_polynomial: Vec::new(),
@@ -375,7 +375,7 @@ mod tests {
                 },
             },
             fri_seed: [10u8; 32],
-            security_level: crate::fri::FriSecurityLevel::Standard,
+            security_level: crate::fri::types::FriSecurityLevel::Standard,
         }
     }
 

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -10,7 +10,7 @@ use std::convert::TryInto;
 use crate::config::{AirSpecId, ParamDigest, ProofKind};
 use crate::field::prime_field::{CanonicalSerialize, FieldDeserializeError};
 use crate::field::FieldElement;
-use crate::fri::{FriProof, FriQuery, FriQueryLayer, FriSecurityLevel};
+use crate::fri::types::{FriProof, FriQuery, FriQueryLayer, FriSecurityLevel};
 use crate::hash::merkle::{MerkleIndex, MerklePathElement};
 use crate::hash::Hasher;
 use crate::proof::public_inputs::{
@@ -728,7 +728,7 @@ mod tests {
         PROOF_VERSION_V1,
     };
     use crate::field::FieldElement;
-    use crate::fri::FriSecurityLevel;
+    use crate::fri::types::FriSecurityLevel;
     use crate::proof::prover::build_envelope as build_proof_envelope;
     use crate::proof::public_inputs::{ExecutionHeaderV1, PublicInputVersion, PublicInputs};
     use crate::utils::serialization::{DigestBytes, WitnessBlob};

--- a/src/proof/prover.rs
+++ b/src/proof/prover.rs
@@ -13,7 +13,7 @@ use crate::config::{
     ProverContext,
 };
 use crate::field::FieldElement;
-use crate::fri::{FriError, FriProof, FriSecurityLevel};
+use crate::fri::types::{FriError, FriProof, FriSecurityLevel};
 use crate::hash::Hasher;
 use crate::proof::envelope::{
     compute_commitment_digest, map_public_to_config_kind, serialize_public_inputs,

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -9,7 +9,8 @@ use crate::config::{
     ProofKind as ConfigProofKind, ProofKindLayout, ProofSystemConfig, VerifierContext,
 };
 use crate::field::FieldElement;
-use crate::fri::{FriError, FriSecurityLevel, FriVerifier};
+use crate::fri::types::{FriError, FriSecurityLevel};
+use crate::fri::FriVerifier;
 use crate::hash::Hasher;
 use crate::proof::envelope::{
     compute_commitment_digest, compute_integrity_digest, map_public_to_config_kind,
@@ -370,11 +371,15 @@ fn map_security_level(profile: &crate::config::ProfileConfig) -> FriSecurityLeve
 fn map_fri_error(error: FriError) -> VerificationFailure {
     match error {
         FriError::EmptyCodeword => VerificationFailure::ErrFRILayerRootMismatch,
+        FriError::VersionMismatch { .. } => VerificationFailure::ErrFRILayerRootMismatch,
         FriError::QueryOutOfRange { .. } => VerificationFailure::ErrFRIQueryOutOfRange,
         FriError::PathInvalid { .. } => VerificationFailure::ErrFRIPathInvalid,
         FriError::LayerRootMismatch { .. } => VerificationFailure::ErrFRILayerRootMismatch,
         FriError::SecurityLevelMismatch => VerificationFailure::ErrFRILayerRootMismatch,
         FriError::QueryBudgetMismatch { .. } => VerificationFailure::ErrFRILayerRootMismatch,
+        FriError::FoldingConstraintViolated { .. } => VerificationFailure::ErrFRILayerRootMismatch,
+        FriError::OodsInvalid => VerificationFailure::ErrFRILayerRootMismatch,
+        FriError::Serialization(_) => VerificationFailure::ErrFRIPathInvalid,
         FriError::InvalidStructure(_) => VerificationFailure::ErrFRIPathInvalid,
     }
 }

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -15,7 +15,7 @@ use rpp_stark::proof::transcript::{Transcript, TranscriptBlockContext, Transcrip
 use rpp_stark::proof::verifier::verify_proof_bytes;
 use rpp_stark::utils::serialization::{DigestBytes, ProofBytes};
 
-use rpp_stark::fri::{FriProof, FriQuery, FriQueryLayer, FriSecurityLevel};
+use rpp_stark::fri::types::{FriProof, FriQuery, FriQueryLayer, FriSecurityLevel};
 use rpp_stark::hash::merkle::{MerkleIndex, MerklePathElement};
 
 const ALPHA_VECTOR_LEN: usize = 4;


### PR DESCRIPTION
## Summary
- introduce a dedicated `fri::types` module containing shared proof structures, enums, and the expanded `FriError` definition
- rework the quartic FRI implementation to consume the shared types and re-export them through `fri::mod`
- update prover, verifier, batching, and tests to pull definitions from the new module and handle the extended error variants

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e2942f15b08326bc4f3fe1e7b48223