### PR TITLE
Refactor FRI folding to binary arity

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -166,7 +166,7 @@ fn build_sample_envelope(
         ood_openings,
         fri_proof,
         fri_parameters: FriParametersMirror {
-            fold: 4,
+            fold: 2,
             cap_degree: profile.limits.max_layers as u16,
             cap_size: profile.limits.max_queries as u32,
             query_budget: profile.fri_queries,

--- a/src/fft/ifft.rs
+++ b/src/fft/ifft.rs
@@ -103,7 +103,10 @@ mod tests {
         forward.forward(&mut values);
         inverse.inverse(&mut values);
 
-        assert_eq!(values, original, "IFFT must invert the natural-order forward transform");
+        assert_eq!(
+            values, original,
+            "IFFT must invert the natural-order forward transform"
+        );
     }
 
     #[test]

--- a/src/fft/lde.rs
+++ b/src/fft/lde.rs
@@ -440,14 +440,20 @@ mod tests {
                 seen[index] = true;
             }
         }
-        assert!(seen.into_iter().all(|flag| flag), "row-major mapping must cover the domain");
+        assert!(
+            seen.into_iter().all(|flag| flag),
+            "row-major mapping must cover the domain"
+        );
 
         let hi_sec = LowDegreeExtender::new(4, 3, &PROFILE_HISEC_X16);
         for column in 0..hi_sec.trace_columns() {
             for row in 0..hi_sec.extended_rows() {
                 let index = hi_sec.lde_index(row, column);
                 let expected = column * hi_sec.extended_rows() + row;
-                assert_eq!(index, expected, "column-interleaved mapping must be deterministic");
+                assert_eq!(
+                    index, expected,
+                    "column-interleaved mapping must be deterministic"
+                );
             }
         }
     }
@@ -481,7 +487,10 @@ mod tests {
                 }
             }
 
-            assert!(visited.into_iter().all(|flag| flag), "chunks must cover the entire domain");
+            assert!(
+                visited.into_iter().all(|flag| flag),
+                "chunks must cover the entire domain"
+            );
             assert_eq!(
                 reconstructed, reference,
                 "LDE output must be byte-identical regardless of worker count ({worker_count})"

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -502,7 +502,10 @@ mod tests {
         forward.forward(&mut values);
         inverse.inverse(&mut values);
 
-        assert_eq!(values, original, "FFT followed by IFFT must recover the input");
+        assert_eq!(
+            values, original,
+            "FFT followed by IFFT must recover the input"
+        );
     }
 
     #[test]
@@ -514,7 +517,10 @@ mod tests {
 
         let plan = Radix2Fft::natural_order(log2_size);
         let cached_root = from_montgomery_repr(plan.domain().generators.forward[1]);
-        assert_eq!(cached_root, first, "generator table must reuse the derived primitive root");
+        assert_eq!(
+            cached_root, first,
+            "generator table must reuse the derived primitive root"
+        );
     }
 
     #[test]

--- a/src/fri/config.rs
+++ b/src/fri/config.rs
@@ -15,8 +15,8 @@ pub type ParameterDigest = &'static str;
 pub struct FriProfile {
     /// Human readable profile identifier.
     pub name: &'static str,
-    /// Folding factor applied to each layer; we only expose quartic
-    /// folding in this module.
+    /// Folding factor applied to each layer; we expose the canonical binary
+    /// folding schedule in this module.
     pub folding_factor: usize,
     /// Number of sampling queries performed by the verifier.
     pub query_count: usize,
@@ -29,7 +29,7 @@ pub struct FriProfile {
 /// Standard security profile targeting typical rollup deployments.
 pub const STANDARD_FRI_PROFILE: FriProfile = FriProfile {
     name: "standard",
-    folding_factor: 4,
+    folding_factor: 2,
     query_count: 64,
     target_depth: 6,
     parameter_digest: "31d7f096bd7cf0ebc5d4d88dbcccf20ebb6a520fe52b39cac3d1a1a0f1d5e2aa",
@@ -38,7 +38,7 @@ pub const STANDARD_FRI_PROFILE: FriProfile = FriProfile {
 /// High security profile with an increased query budget.
 pub const HISEC_FRI_PROFILE: FriProfile = FriProfile {
     name: "hisec",
-    folding_factor: 4,
+    folding_factor: 2,
     query_count: 96,
     target_depth: 8,
     parameter_digest: "8f44b61cfe2b67ab681a2a19d4e9febb0e5bc2b1de9a5596d1f52e8f8e0cd5a4",

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -1,4 +1,7 @@
-//! Fully deterministic quartic FRI implementation used by the prover and verifier.
+//! Fully deterministic binary FRI implementation used by the prover and verifier.
+//! The folding helpers expose the canonical coset-shift schedule derived from
+//! [`StarkParams`](crate::params::StarkParams) so that integrators can mirror the
+//! prover's domain adjustments.
 //!
 //! The implementation in this module intentionally favours readability and
 //! auditability over raw performance.  All hashing is performed using the
@@ -15,7 +18,10 @@ pub mod types;
 
 pub(crate) use crate::hash::{pseudo_blake3, PseudoBlake3Xof};
 pub use batch::{BatchDigest, BatchQueryPosition, BatchSeed, FriBatch, FriBatchVerificationApi};
-pub use folding::{quartic_fold, FoldingLayer, FoldingLayout, LayerCommitment, QUARTIC_FOLD};
+pub use folding::{
+    binary_fold, coset_shift_schedule, FoldingLayer, FoldingLayout, LayerCommitment,
+    BINARY_FOLD_ARITY,
+};
 pub use proof::{derive_query_plan_id, FriVerifier};
 pub use types::{
     FriError, FriParamsView, FriProof, FriProofVersion, FriQuery, FriQueryLayer, FriSecurityLevel,
@@ -109,7 +115,7 @@ pub(crate) fn hash_leaf(value: &FieldElement) -> [u8; 32] {
     hash(&payload).into()
 }
 
-/// Hashes four children digests into their parent digest.
+/// Hashes four child digests into their parent digest.
 #[inline]
 pub(crate) fn hash_internal(children: &[[u8; 32]; 4]) -> [u8; 32] {
     let mut payload = Vec::with_capacity(128);

--- a/src/fri/types.rs
+++ b/src/fri/types.rs
@@ -39,7 +39,7 @@ impl FriSecurityLevel {
 /// Version tag attached to FRI proofs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FriProofVersion {
-    /// Initial version of the quartic FRI proof format.
+    /// Initial version of the binary FRI proof format.
     V1,
 }
 

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -309,7 +309,7 @@ impl ProofEnvelopeBody {
 /// Mirror of the FRI parameters stored inside the envelope body.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FriParametersMirror {
-    /// Folding factor (fixed to four in the current implementation).
+    /// Folding factor (fixed to two in the current implementation).
     pub fold: u8,
     /// Degree of the cap polynomial.
     pub cap_degree: u16,
@@ -322,7 +322,7 @@ pub struct FriParametersMirror {
 impl Default for FriParametersMirror {
     fn default() -> Self {
         Self {
-            fold: 4,
+            fold: 2,
             cap_degree: 0,
             cap_size: 0,
             query_budget: 0,
@@ -766,7 +766,7 @@ mod tests {
             fri_layer_roots,
             ood_openings: Vec::new(),
             fri_parameters: FriParametersMirror {
-                fold: 4,
+                fold: 2,
                 cap_degree: 256,
                 cap_size: fri_proof.final_polynomial.len() as u32,
                 query_budget: FriSecurityLevel::Standard.query_budget() as u16,

--- a/src/proof/prover.rs
+++ b/src/proof/prover.rs
@@ -5,7 +5,7 @@
 //! 1. Parse the witness into a list of LDE evaluations.
 //! 2. Compute the initial commitment roots and bind them to the transcript.
 //! 3. Derive Fiat–Shamir challenges (α-vector, OOD points, FRI seed).
-//! 4. Produce a quartic FRI proof using the deterministic seed.
+//! 4. Produce a binary FRI proof using the deterministic seed.
 //! 5. Assemble the envelope header/body, compute digests and enforce size limits.
 
 use crate::config::{
@@ -40,7 +40,7 @@ pub enum ProverError {
     MalformedWitness(&'static str),
     /// Failed to derive Fiat–Shamir challenges.
     Transcript(crate::proof::transcript::TranscriptError),
-    /// Quartic FRI prover returned an error.
+    /// Binary FRI prover returned an error.
     Fri(FriError),
     /// The resulting proof exceeded the configured size limit.
     ProofTooLarge { actual: usize, limit: u32 },
@@ -128,7 +128,7 @@ pub fn build_envelope(
     let commitment_digest = compute_commitment_digest(&core_root, &aux_root, &fri_layer_roots);
 
     let fri_parameters = FriParametersMirror {
-        fold: 4,
+        fold: 2,
         cap_degree: context.profile.fri_depth_range.max as u16,
         cap_size: fri_proof.final_polynomial.len() as u32,
         query_budget: security_level.query_budget() as u16,


### PR DESCRIPTION
## Summary
- switch the FRI folding helpers to a binary arity, expose coset shift metadata, and update exported constants
- adapt the prover to the new folding routine, including deterministic Stark parameter selection and binary query index progression
- align profile metadata, envelope mirroring, and documentation with the binary fold factor

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e2994eba8c8326926d16b3c8261680