### PR TITLE
Switch FRI proof to binary arity

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -485,9 +485,9 @@ const fn digest(bytes: [u8; 32]) -> DigestBytes {
     DigestBytes { bytes }
 }
 
-/// Canonical Merkle scheme identifier (`BLAKE3_4ARY_V1`).
-pub const MERKLE_SCHEME_ID_BLAKE3_4ARY_V1: MerkleSchemeId = MerkleSchemeId(digest([
-    b'B', b'L', b'A', b'K', b'E', b'3', b'_', b'4', b'A', b'R', b'Y', b'_', b'V', b'1', 0, 0, 0, 0,
+/// Canonical Merkle scheme identifier (`BLAKE3_2ARY_V1`).
+pub const MERKLE_SCHEME_ID_BLAKE3_2ARY_V1: MerkleSchemeId = MerkleSchemeId(digest([
+    b'B', b'L', b'A', b'K', b'E', b'3', b'_', b'2', b'A', b'R', b'Y', b'_', b'V', b'1', 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ]));
 
@@ -497,10 +497,10 @@ pub const TRANSCRIPT_VERSION_ID_RPP_FS_V1: TranscriptVersionId = TranscriptVersi
     0, 0, 0, 0, 0, 0, 0, 0, 1,
 ]));
 
-/// Canonical FRI folding plan identifier (fold factor 4).
-pub const FRI_PLAN_ID_FOLD4_V1: FriPlanId = FriPlanId(digest([
-    b'F', b'R', b'I', b'_', b'P', b'L', b'A', b'N', b'_', b'F', b'4', b'_', b'V', b'1', 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
+/// Canonical FRI folding plan identifier (fold factor 2).
+pub const FRI_PLAN_ID_FOLD2_V1: FriPlanId = FriPlanId(digest([
+    b'F', b'R', b'I', b'_', b'P', b'L', b'A', b'N', b'_', b'F', b'2', b'_', b'V', b'1', 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
 ]));
 
 /// Poseidon parameter identifier for `rf=8, rp=56`.
@@ -554,9 +554,9 @@ pub const AIR_SPEC_IDS_V1: AirSpecLayout = ProofKindLayout {
 /// Common identifiers shared across profiles.
 pub const COMMON_IDENTIFIERS: CommonIdentifiers = CommonIdentifiers {
     field_id: FIELD_ID_GOLDILOCKS_64,
-    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_4ARY_V1,
+    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_2ARY_V1,
     transcript_version_id: TRANSCRIPT_VERSION_ID_RPP_FS_V1,
-    fri_plan_id: FRI_PLAN_ID_FOLD4_V1,
+    fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
 };
 
 /// Standard profile configuration (`PROFILE_STD`).
@@ -572,9 +572,9 @@ pub const PROFILE_STANDARD_CONFIG: ProfileConfig = ProfileConfig {
         partial_rounds: 56,
     },
     poseidon_param_id: POSEIDON_PARAM_ID_STANDARD,
-    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_4ARY_V1,
+    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_2ARY_V1,
     transcript_version_id: TRANSCRIPT_VERSION_ID_RPP_FS_V1,
-    fri_plan_id: FRI_PLAN_ID_FOLD4_V1,
+    fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
     batch_verification_enabled: true,
     max_threads: 8,
     limits: ResourceLimits {
@@ -618,9 +618,9 @@ pub const PROFILE_HIGH_SECURITY_CONFIG: ProfileConfig = ProfileConfig {
         partial_rounds: 60,
     },
     poseidon_param_id: POSEIDON_PARAM_ID_HISEC,
-    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_4ARY_V1,
+    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_2ARY_V1,
     transcript_version_id: TRANSCRIPT_VERSION_ID_RPP_FS_V1,
-    fri_plan_id: FRI_PLAN_ID_FOLD4_V1,
+    fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
     batch_verification_enabled: true,
     max_threads: 12,
     limits: ResourceLimits {
@@ -664,9 +664,9 @@ pub const PROFILE_THROUGHPUT_CONFIG: ProfileConfig = ProfileConfig {
         partial_rounds: 56,
     },
     poseidon_param_id: POSEIDON_PARAM_ID_STANDARD,
-    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_4ARY_V1,
+    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_2ARY_V1,
     transcript_version_id: TRANSCRIPT_VERSION_ID_RPP_FS_V1,
-    fri_plan_id: FRI_PLAN_ID_FOLD4_V1,
+    fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
     batch_verification_enabled: true,
     max_threads: 8,
     limits: ResourceLimits {

--- a/src/fri/config.rs
+++ b/src/fri/config.rs
@@ -4,7 +4,8 @@
 /// Canonical digest representation for a FRI parameter set.
 ///
 /// The digest is computed over the canonical serialization of the
-/// folding factor, query schedule, and target depth using BLAKE3.
+/// folding factor, folding mode, query schedule, and target depth
+/// using BLAKE3.
 /// The hexadecimal strings exposed below allow integrators to pin
 /// protocol parameters without embedding executable verification logic.
 pub type ParameterDigest = &'static str;
@@ -32,7 +33,7 @@ pub const STANDARD_FRI_PROFILE: FriProfile = FriProfile {
     folding_factor: 2,
     query_count: 64,
     target_depth: 6,
-    parameter_digest: "31d7f096bd7cf0ebc5d4d88dbcccf20ebb6a520fe52b39cac3d1a1a0f1d5e2aa",
+    parameter_digest: "5570706d57436b4fa198d0e8c8a6d3fa01d8c348c602248b066ee8f3fe0eb566",
 };
 
 /// High security profile with an increased query budget.
@@ -41,5 +42,5 @@ pub const HISEC_FRI_PROFILE: FriProfile = FriProfile {
     folding_factor: 2,
     query_count: 96,
     target_depth: 8,
-    parameter_digest: "8f44b61cfe2b67ab681a2a19d4e9febb0e5bc2b1de9a5596d1f52e8f8e0cd5a4",
+    parameter_digest: "40b923845a41a78da7bdef951f541ae1b6b30794b0244a54b19fc5801d686b06",
 };

--- a/src/fri/folding.rs
+++ b/src/fri/folding.rs
@@ -141,9 +141,8 @@ fn log2(size: usize) -> usize {
 pub fn binary_fold(
     values: &[FieldElement],
     beta: FieldElement,
-    params: &StarkParams,
+    coset_shift: FieldElement,
 ) -> Vec<FieldElement> {
-    let coset_shift = derive_coset_shift(params);
     let mut result = Vec::with_capacity((values.len() + BINARY_FOLD_ARITY - 1) / BINARY_FOLD_ARITY);
     let mut chunks = values.chunks_exact(BINARY_FOLD_ARITY);
 
@@ -161,7 +160,7 @@ pub fn binary_fold(
     result
 }
 
-fn derive_coset_shift(params: &StarkParams) -> FieldElement {
+pub(crate) fn derive_coset_shift(params: &StarkParams) -> FieldElement {
     match params.fri().folding {
         FriFolding::Natural => FieldElement::ONE,
         FriFolding::Coset => FieldElement::GENERATOR,
@@ -205,8 +204,9 @@ mod tests {
 
     #[test]
     fn coset_shift_schedule_tracks_phi_mapping() {
-        let params =
-            StarkParamsBuilder::from_profile(BuiltinProfile::PROFILE_X8).build().unwrap();
+        let params = StarkParamsBuilder::from_profile(BuiltinProfile::PROFILE_X8)
+            .build()
+            .unwrap();
         let schedule = coset_shift_schedule(&params, 3);
         assert_eq!(schedule.len(), 3);
         assert_eq!(schedule[0], derive_coset_shift(&params));

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -19,8 +19,8 @@ pub mod types;
 pub(crate) use crate::hash::{pseudo_blake3, PseudoBlake3Xof};
 pub use batch::{BatchDigest, BatchQueryPosition, BatchSeed, FriBatch, FriBatchVerificationApi};
 pub use folding::{
-    binary_fold, coset_shift_schedule, FoldingLayer, FoldingLayout, LayerCommitment,
-    BINARY_FOLD_ARITY, next_domain_size, parent_index, phi,
+    binary_fold, coset_shift_schedule, next_domain_size, parent_index, phi, FoldingLayer,
+    FoldingLayout, LayerCommitment, BINARY_FOLD_ARITY,
 };
 pub use proof::{derive_query_plan_id, FriVerifier};
 pub use types::{
@@ -115,10 +115,10 @@ pub(crate) fn hash_leaf(value: &FieldElement) -> [u8; 32] {
     hash(&payload).into()
 }
 
-/// Hashes four child digests into their parent digest.
+/// Hashes two child digests into their parent digest.
 #[inline]
-pub(crate) fn hash_internal(children: &[[u8; 32]; 4]) -> [u8; 32] {
-    let mut payload = Vec::with_capacity(128);
+pub(crate) fn hash_internal(children: &[[u8; 32]; 2]) -> [u8; 32] {
+    let mut payload = Vec::with_capacity(64);
     for child in children {
         payload.extend_from_slice(child);
     }

--- a/src/hash/blake3.rs
+++ b/src/hash/blake3.rs
@@ -43,8 +43,8 @@ impl Blake3Domain {
                 description: "Batch aggregation seed namespace",
             },
             Blake3Domain {
-                canonical_prefix: "RPP-MERKLE-4",
-                description: "4-ary Merkle commitment namespace",
+                canonical_prefix: "RPP-MERKLE-2",
+                description: "Binary Merkle commitment namespace",
             },
         ]
     }

--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -276,9 +276,9 @@ mod tests {
             param_digest,
             common_ids: CommonIdentifiers {
                 field_id: crate::config::FIELD_ID_GOLDILOCKS_64,
-                merkle_scheme_id: crate::config::MERKLE_SCHEME_ID_BLAKE3_4ARY_V1,
+                merkle_scheme_id: crate::config::MERKLE_SCHEME_ID_BLAKE3_2ARY_V1,
                 transcript_version_id: crate::config::TRANSCRIPT_VERSION_ID_RPP_FS_V1,
-                fri_plan_id: crate::config::FRI_PLAN_ID_FOLD4_V1,
+                fri_plan_id: crate::config::FRI_PLAN_ID_FOLD2_V1,
             },
             limits: PROFILE_STANDARD_CONFIG.limits.clone(),
             metrics: None,

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -599,7 +599,7 @@ fn deserialize_fri_proof(bytes: &[u8]) -> Result<FriProof, EnvelopeError> {
             let mut path = Vec::with_capacity(path_len);
             for _ in 0..path_len {
                 let index = cursor.read_u8()?;
-                let mut siblings = [[0u8; 32]; 3];
+                let mut siblings = [[0u8; 32]; 1];
                 for sibling in siblings.iter_mut() {
                     *sibling = cursor.read_digest()?;
                 }

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -241,7 +241,7 @@ fn precheck_body(
     if body.fri_proof.security_level != security_level {
         return Err(VerificationFailure::ErrFRILayerRootMismatch);
     }
-    if body.fri_parameters.fold != 4
+    if body.fri_parameters.fold != 2
         || body.fri_parameters.query_budget as usize != security_level.query_budget()
     {
         return Err(VerificationFailure::ErrEnvelopeMalformed);

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -243,7 +243,7 @@ fn build_envelope(
         ood_openings,
         fri_proof,
         fri_parameters: FriParametersMirror {
-            fold: 4,
+            fold: 2,
             cap_degree: context.profile.fri_depth_range.max as u16,
             cap_size: final_poly_len as u32,
             query_budget: security_level.query_budget() as u16,
@@ -264,7 +264,7 @@ fn build_queries(layer_count: usize, query_count: usize) -> Vec<FriQuery> {
                     value: FieldElement::ZERO,
                     path: vec![MerklePathElement {
                         index: MerkleIndex(0),
-                        siblings: [[0u8; 32]; 3],
+                        siblings: [[0u8; 32]; 1],
                     }],
                 })
                 .collect(),


### PR DESCRIPTION
## Summary
- convert the FRI Merkle tree and associated hashing helpers to binary arity
- propagate coset-aware folding through `binary_fold` along with new prover/verifier helpers
- refresh FRI configuration identifiers and update verifier/tests for the binary layout

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e2a6401db083268290b9f0047ae774