### PR TITLE
Implement FRI prover entry point and fold challenge tracking

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -154,6 +154,7 @@ fn build_sample_envelope(
         security_level: profile_to_security_level(profile.id),
         initial_domain_size: 16,
         layer_roots: fri_layer_roots.clone(),
+        fold_challenges: Vec::new(),
         final_polynomial,
         final_polynomial_digest: sample_digest(&mut reader),
         queries: Vec::new(),

--- a/src/fri/layer.rs
+++ b/src/fri/layer.rs
@@ -41,7 +41,8 @@ impl LayerTree {
         levels.push(current.clone());
 
         while current.len() > 1 {
-            let mut next = Vec::with_capacity((current.len() + BINARY_FOLD_ARITY - 1) / BINARY_FOLD_ARITY);
+            let mut next =
+                Vec::with_capacity((current.len() + BINARY_FOLD_ARITY - 1) / BINARY_FOLD_ARITY);
             for chunk in current.chunks(BINARY_FOLD_ARITY) {
                 let mut children = [[0u8; 32]; BINARY_FOLD_ARITY];
                 for (position, slot) in children.iter_mut().enumerate() {
@@ -110,7 +111,11 @@ pub(crate) struct FriLayer {
 
 impl FriLayer {
     /// Materialises a new layer by hashing the provided evaluations.
-    pub(crate) fn new(index: usize, coset_shift: FieldElement, evaluations: Vec<FieldElement>) -> Self {
+    pub(crate) fn new(
+        index: usize,
+        coset_shift: FieldElement,
+        evaluations: Vec<FieldElement>,
+    ) -> Self {
         let domain_size = evaluations.len();
         let tree = LayerTree::new(&evaluations);
         Self {
@@ -159,4 +164,3 @@ impl FriLayer {
         Ok(FriQueryLayer { value, path })
     }
 }
-

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -15,6 +15,7 @@ pub mod config;
 mod folding;
 mod layer;
 mod proof;
+mod prover;
 pub mod types;
 
 pub(crate) use crate::hash::{pseudo_blake3, PseudoBlake3Xof};
@@ -25,6 +26,7 @@ pub use folding::{
 };
 pub(crate) use layer::FriLayer;
 pub use proof::{derive_query_plan_id, FriVerifier};
+pub use prover::fri_prove;
 pub use types::{
     FriError, FriParamsView, FriProof, FriProofVersion, FriQuery, FriQueryLayer, FriSecurityLevel,
     FriTranscriptSeed, SerKind,

--- a/src/fri/prover.rs
+++ b/src/fri/prover.rs
@@ -1,0 +1,124 @@
+use super::folding::{binary_fold, coset_shift_schedule, parent_index};
+use super::layer::FriLayer;
+use super::proof::{derive_query_positions, hash_final_layer};
+use super::types::{FriError, FriParamsView, FriProof, FriQuery, FriSecurityLevel};
+use crate::field::FieldElement;
+use crate::params::StarkParams;
+use crate::transcript::{Felt, Transcript, TranscriptError, TranscriptLabel};
+use crate::utils::serialization::DigestBytes;
+
+fn map_transcript_error(err: TranscriptError) -> FriError {
+    match err {
+        TranscriptError::InvalidLabel => FriError::InvalidStructure("transcript-label"),
+        TranscriptError::RangeZero => FriError::InvalidStructure("transcript-range"),
+        TranscriptError::Overflow => FriError::InvalidStructure("transcript-overflow"),
+        TranscriptError::Serialization(_) => FriError::InvalidStructure("transcript-ser"),
+        TranscriptError::BoundsViolation => FriError::InvalidStructure("transcript-bounds"),
+        TranscriptError::Unsupported => FriError::InvalidStructure("transcript-unsupported"),
+    }
+}
+
+fn security_level_from_query_count(count: usize) -> Result<FriSecurityLevel, FriError> {
+    if count == FriSecurityLevel::Standard.query_budget() {
+        Ok(FriSecurityLevel::Standard)
+    } else if count == FriSecurityLevel::HiSec.query_budget() {
+        Ok(FriSecurityLevel::HiSec)
+    } else if count == FriSecurityLevel::Throughput.query_budget() {
+        Ok(FriSecurityLevel::Throughput)
+    } else {
+        Err(FriError::InvalidStructure("unsupported-query-count"))
+    }
+}
+
+/// Executes the canonical binary FRI prover against the supplied transcript.
+pub fn fri_prove(
+    evaluations: &[Felt],
+    params: &StarkParams,
+    transcript: &mut Transcript,
+) -> Result<FriProof, FriError> {
+    if evaluations.is_empty() {
+        return Err(FriError::EmptyCodeword);
+    }
+
+    let query_count = params.fri().queries as usize;
+    let security_level = security_level_from_query_count(query_count)?;
+    let query_plan = super::derive_query_plan_id(security_level, params);
+    let view = FriParamsView::from_params(params, security_level, query_plan);
+
+    let coset_shifts = coset_shift_schedule(params, view.num_layers());
+    let mut layers = Vec::with_capacity(view.num_layers());
+    let mut layer_roots = Vec::with_capacity(view.num_layers());
+    let mut fold_challenges = Vec::with_capacity(view.num_layers());
+
+    let mut current: Vec<FieldElement> = evaluations.to_vec();
+
+    for (layer_index, coset_shift) in coset_shifts.iter().copied().enumerate() {
+        if layer_index > u8::MAX as usize {
+            return Err(FriError::InvalidStructure("layer-index-overflow"));
+        }
+
+        let layer = FriLayer::new(layer_index, coset_shift, current);
+        let root = layer.root();
+        transcript
+            .absorb_digest(
+                TranscriptLabel::FriRoot(layer_index as u8),
+                &DigestBytes { bytes: root },
+            )
+            .map_err(map_transcript_error)?;
+        let eta = transcript
+            .challenge_field(TranscriptLabel::FriFoldChallenge(layer_index as u8))
+            .map_err(map_transcript_error)?;
+        fold_challenges.push(eta);
+        layer_roots.push(root);
+
+        current = binary_fold(layer.evaluations(), eta, layer.coset_shift());
+        layers.push(layer);
+    }
+
+    let final_polynomial = current;
+    let final_polynomial_digest = hash_final_layer(&final_polynomial);
+
+    let count_bytes = (view.query_count() as u32).to_le_bytes();
+    transcript
+        .absorb_bytes(TranscriptLabel::QueryCount, &count_bytes)
+        .map_err(map_transcript_error)?;
+    let query_seed_bytes = transcript
+        .challenge_bytes(TranscriptLabel::QueryIndexStream, 32)
+        .map_err(map_transcript_error)?;
+    let mut query_seed = [0u8; 32];
+    query_seed.copy_from_slice(&query_seed_bytes);
+
+    let positions = derive_query_positions(query_seed, view.query_count(), evaluations.len());
+    let mut queries = Vec::with_capacity(positions.len());
+
+    for &position in &positions {
+        let mut index = position;
+        let mut layers_openings = Vec::with_capacity(layers.len());
+        for layer in layers.iter() {
+            let opening = layer.open(index)?;
+            layers_openings.push(opening);
+            index = parent_index(index);
+        }
+
+        if index >= final_polynomial.len() {
+            return Err(FriError::QueryOutOfRange { position });
+        }
+
+        let final_value = final_polynomial[index];
+        queries.push(FriQuery {
+            position,
+            layers: layers_openings,
+            final_value,
+        });
+    }
+
+    Ok(FriProof {
+        security_level,
+        initial_domain_size: evaluations.len(),
+        layer_roots,
+        fold_challenges,
+        final_polynomial,
+        final_polynomial_digest,
+        queries,
+    })
+}

--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -366,6 +366,7 @@ mod tests {
                         security_level: crate::fri::types::FriSecurityLevel::Standard,
                         initial_domain_size: 1,
                         layer_roots: Vec::new(),
+                        fold_challenges: Vec::new(),
                         final_polynomial: Vec::new(),
                         final_polynomial_digest: [0u8; 32],
                         queries: Vec::new(),

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -229,6 +229,7 @@ fn build_envelope(
         security_level,
         initial_domain_size: 1024,
         layer_roots: fri_layer_roots.clone(),
+        fold_challenges: Vec::new(),
         final_polynomial,
         final_polynomial_digest: [0x33; 32],
         queries,


### PR DESCRIPTION
## Summary
- add a transcript-driven `fri_prove` entry point that orchestrates layer commitments, challenge sampling, folding, and query selection
- extend `FriProof`/`FriParamsView` with fold challenges and richer parameter metadata, and update serialization consumers
- ensure tests, fixtures, and helper utilities carry the new fold challenge field

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e2b213ad588326970dbee3adcf396a