### PR TITLE
Add FRI benchmarking suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ harness = false
 name = "merkle_benches"
 harness = false
 
+[[bench]]
+name = "fri_benches"
+harness = false
+
 [dev-dependencies.criterion]
 version = "0.5"
 features = ["html_reports"]

--- a/benches/fri_benches.rs
+++ b/benches/fri_benches.rs
@@ -1,0 +1,170 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rpp_stark::field::FieldElement;
+use rpp_stark::fri::{
+    binary_fold, coset_shift_schedule, derive_query_plan_id, fri_prove, fri_verify, FriLayer,
+    FriParamsView, FriSecurityLevel,
+};
+use rpp_stark::params::{BuiltinProfile, StarkParams, StarkParamsBuilder};
+use rpp_stark::transcript::{Transcript, TranscriptContext, TranscriptLabel};
+use rpp_stark::utils::serialization::DigestBytes;
+
+#[derive(Clone)]
+struct LayerInput {
+    index: usize,
+    coset_shift: FieldElement,
+    values: Vec<FieldElement>,
+}
+
+struct LayerSchedule {
+    _view: FriParamsView,
+    layers: Vec<LayerInput>,
+}
+
+fn sample_params(level: FriSecurityLevel) -> StarkParams {
+    let mut builder = match level {
+        FriSecurityLevel::HiSec => {
+            StarkParamsBuilder::from_profile(BuiltinProfile::PROFILE_HISEC_X16)
+        }
+        _ => StarkParamsBuilder::from_profile(BuiltinProfile::PROFILE_X8),
+    };
+    builder.fri.queries = level.query_budget() as u16;
+    builder.fri.domain_log2 = 20;
+    builder.build().expect("valid parameters")
+}
+
+fn sample_evaluations(size: usize) -> Vec<FieldElement> {
+    (0..size)
+        .map(|i| FieldElement::from((i as u64) + 1))
+        .collect()
+}
+
+fn stage_transcript_for_fri(params: &StarkParams) -> Transcript {
+    let mut transcript = Transcript::new(params, TranscriptContext::StarkMain);
+    let zero = DigestBytes { bytes: [0u8; 32] };
+    transcript
+        .absorb_digest(TranscriptLabel::PublicInputsDigest, &zero)
+        .expect("public digest");
+    transcript
+        .absorb_digest(TranscriptLabel::TraceRoot, &zero)
+        .expect("trace root");
+    let _ = transcript
+        .challenge_field(TranscriptLabel::TraceChallengeA)
+        .expect("trace challenge");
+    transcript
+        .absorb_digest(TranscriptLabel::CompRoot, &zero)
+        .expect("composition root");
+    let _ = transcript
+        .challenge_field(TranscriptLabel::CompChallengeA)
+        .expect("composition challenge");
+    transcript.fork(TranscriptContext::Fri)
+}
+
+fn build_layer_schedule(params: &StarkParams) -> LayerSchedule {
+    let query_count = params.fri().queries as usize;
+    let security_level = FriSecurityLevel::from_query_count(query_count)
+        .expect("parameters must use a supported query count");
+    let query_plan = derive_query_plan_id(security_level, params);
+    let view = FriParamsView::from_params(params, security_level, query_plan);
+    let coset_shifts = coset_shift_schedule(params, view.num_layers());
+    let mut layers = Vec::with_capacity(coset_shifts.len());
+    let mut current = sample_evaluations(view.initial_domain_size());
+
+    for (layer_index, coset_shift) in coset_shifts.into_iter().enumerate() {
+        let values = current.clone();
+        let eta = FieldElement::from((layer_index as u64) + 7);
+        current = binary_fold(&values, eta, coset_shift);
+        layers.push(LayerInput {
+            index: layer_index,
+            coset_shift,
+            values,
+        });
+    }
+
+    LayerSchedule {
+        _view: view,
+        layers,
+    }
+}
+
+fn bench_layer_commitment(c: &mut Criterion) {
+    let params = sample_params(FriSecurityLevel::Standard);
+    let schedule = build_layer_schedule(&params);
+    let mut group = c.benchmark_group("fri_layer_commitment");
+
+    for layer in &schedule.layers {
+        let label = format!("layer{}_n{}", layer.index, layer.values.len());
+        group.throughput(Throughput::Elements(layer.values.len() as u64));
+        group.bench_with_input(BenchmarkId::new("commit", label), layer, |b, input| {
+            b.iter(|| {
+                let committed = FriLayer::new(input.index, input.coset_shift, input.values.clone());
+                black_box(committed.root());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_folding_throughput(c: &mut Criterion) {
+    let params = sample_params(FriSecurityLevel::Standard);
+    let schedule = build_layer_schedule(&params);
+    let mut group = c.benchmark_group("fri_binary_fold");
+
+    for layer in &schedule.layers {
+        let eta = FieldElement::from((layer.index as u64) + 7);
+        let label = format!("layer{}_n{}", layer.index, layer.values.len());
+        group.throughput(Throughput::Elements(layer.values.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("fold", label),
+            &layer.values,
+            |b, values| {
+                b.iter(|| {
+                    black_box(binary_fold(values, eta, layer.coset_shift));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn level_label(level: FriSecurityLevel) -> &'static str {
+    match level {
+        FriSecurityLevel::Standard => "standard",
+        FriSecurityLevel::HiSec => "hisec",
+        FriSecurityLevel::Throughput => "throughput",
+    }
+}
+
+fn bench_verifier_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fri_verifier_latency");
+
+    for level in [
+        FriSecurityLevel::Throughput,
+        FriSecurityLevel::Standard,
+        FriSecurityLevel::HiSec,
+    ] {
+        let params = sample_params(level);
+        let domain_size = 1usize << (params.fri().domain_log2 as usize);
+        let evaluations = sample_evaluations(domain_size);
+        let mut prover_transcript = stage_transcript_for_fri(&params);
+        let proof = fri_prove(&evaluations, &params, &mut prover_transcript).expect("fri proof");
+
+        group.bench_function(BenchmarkId::new("verify", level_label(level)), |b| {
+            b.iter(|| {
+                let mut transcript = stage_transcript_for_fri(&params);
+                fri_verify(black_box(&proof), &params, &mut transcript).expect("verification");
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    fri_benches,
+    bench_layer_commitment,
+    bench_folding_throughput,
+    bench_verifier_latency
+);
+criterion_main!(fri_benches);

--- a/benches/merkle_benches.rs
+++ b/benches/merkle_benches.rs
@@ -1,8 +1,6 @@
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use rpp_stark::merkle::{DeterministicMerkleHasher, Leaf, MerkleCommit, MerkleTree};
-use rpp_stark::params::builder::StarkParamsBuilder;
-use rpp_stark::params::types::{Endianness, HashKind, MerkleArity};
-use rpp_stark::params::StarkParams;
+use rpp_stark::params::{Endianness, HashKind, MerkleArity, StarkParams, StarkParamsBuilder};
 
 fn build_params(arity: MerkleArity, leaf_width: u8) -> StarkParams {
     let mut builder = StarkParamsBuilder::new();
@@ -77,9 +75,9 @@ fn bench_verify(c: &mut Criterion) {
     let params = build_params(MerkleArity::Binary, 4);
     let sizes = [16usize, 64, 256];
     let leaves = make_leaves(1 << 12, params.merkle().leaf_width);
-    let (root, aux) =
-        MerkleTree::<DeterministicMerkleHasher>::commit(&params, leaves.clone().into_iter())
-            .unwrap();
+    let mut tree = MerkleTree::<DeterministicMerkleHasher>::new(&params).unwrap();
+    let root = tree.commit(leaves.clone().into_iter()).unwrap();
+    let aux = tree.into_aux();
     for &queries in &sizes {
         let indices: Vec<u32> = (0..queries as u32).collect();
         let proof = MerkleTree::<DeterministicMerkleHasher>::open(&params, &aux, &indices).unwrap();

--- a/benches/transcript_benches.rs
+++ b/benches/transcript_benches.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rpp_stark::params::builder::{BuiltinProfile, StarkParamsBuilder};
+use rpp_stark::params::{BuiltinProfile, StarkParamsBuilder};
 use rpp_stark::transcript::{Transcript, TranscriptContext, TranscriptLabel};
 use rpp_stark::utils::serialization::DigestBytes;
 

--- a/src/fri/layer.rs
+++ b/src/fri/layer.rs
@@ -129,7 +129,7 @@ pub(crate) fn verify_query_opening(
 
 /// Encapsulates the state of a single FRI layer (values, commitment and domain metadata).
 #[derive(Debug, Clone)]
-pub(crate) struct FriLayer {
+pub struct FriLayer {
     index: usize,
     domain_size: usize,
     coset_shift: FieldElement,
@@ -139,11 +139,7 @@ pub(crate) struct FriLayer {
 
 impl FriLayer {
     /// Materialises a new layer by hashing the provided evaluations.
-    pub(crate) fn new(
-        index: usize,
-        coset_shift: FieldElement,
-        evaluations: Vec<FieldElement>,
-    ) -> Self {
+    pub fn new(index: usize, coset_shift: FieldElement, evaluations: Vec<FieldElement>) -> Self {
         let domain_size = evaluations.len();
         let tree = LayerTree::new(&evaluations);
         Self {
@@ -156,33 +152,33 @@ impl FriLayer {
     }
 
     /// Returns the index of the layer within the folding schedule.
-    pub(crate) fn index(&self) -> usize {
+    pub fn index(&self) -> usize {
         self.index
     }
 
     /// Size of the evaluation domain covered by the layer.
     #[allow(dead_code)]
-    pub(crate) fn domain_size(&self) -> usize {
+    pub fn domain_size(&self) -> usize {
         self.domain_size
     }
 
     /// Coset shift applied to the evaluations stored in the layer.
-    pub(crate) fn coset_shift(&self) -> FieldElement {
+    pub fn coset_shift(&self) -> FieldElement {
         self.coset_shift
     }
 
     /// Accessor returning the evaluations committed by the layer.
-    pub(crate) fn evaluations(&self) -> &[FieldElement] {
+    pub fn evaluations(&self) -> &[FieldElement] {
         &self.evaluations
     }
 
     /// Returns the Merkle root associated with the layer.
-    pub(crate) fn root(&self) -> [u8; 32] {
+    pub fn root(&self) -> [u8; 32] {
         self.tree.root()
     }
 
     /// Opens the layer at `position`, returning the evaluation and its path.
-    pub(crate) fn open(&self, position: usize) -> Result<FriQueryLayerProof, FriError> {
+    pub fn open(&self, position: usize) -> Result<FriQueryLayerProof, FriError> {
         if position >= self.domain_size {
             return Err(FriError::QueryOutOfRange { position });
         }

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -25,7 +25,7 @@ pub use folding::{
     binary_fold, coset_shift_schedule, next_domain_size, parent_index, phi, FoldingLayer,
     FoldingLayout, LayerCommitment, BINARY_FOLD_ARITY,
 };
-pub(crate) use layer::FriLayer;
+pub use layer::FriLayer;
 pub use proof::{
     derive_query_plan_id, DeepOodsProof, FriProof, FriQueryLayerProof, FriQueryProof, FriVerifier,
 };

--- a/src/fri/types.rs
+++ b/src/fri/types.rs
@@ -27,6 +27,18 @@ impl FriSecurityLevel {
         }
     }
 
+    /// Infers the security profile corresponding to a query budget.
+    pub fn from_query_count(count: usize) -> Option<Self> {
+        match count {
+            c if c == FriSecurityLevel::Standard.query_budget() => Some(FriSecurityLevel::Standard),
+            c if c == FriSecurityLevel::HiSec.query_budget() => Some(FriSecurityLevel::HiSec),
+            c if c == FriSecurityLevel::Throughput.query_budget() => {
+                Some(FriSecurityLevel::Throughput)
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn tag(self) -> &'static str {
         match self {
             FriSecurityLevel::Standard => "STD",


### PR DESCRIPTION
## Summary
- add a dedicated `fri_benches` harness to time layer commitments, folding throughput, and verifier latency across representative parameters
- expose `FriLayer` and a query-count helper so the benchmarks can reuse the production setup routines
- update existing bench crates to use the public parameter exports and register the new benchmark target in `Cargo.toml`

## Testing
- cargo bench --no-run

------
https://chatgpt.com/codex/tasks/task_e_68e2c61570408326a5a2be873b98b918