### PR TITLE
Enhance LFSR AIR test coverage

### DIFF
--- a/src/air/example/snapshots/rpp_stark__air__example__lfsr__tests__public_input_digest_seed3_len8.snap
+++ b/src/air/example/snapshots/rpp_stark__air__example__lfsr__tests__public_input_digest_seed3_len8.snap
@@ -1,0 +1,40 @@
+---
+source: src/air/example/lfsr.rs
+assertion_line: 502
+expression: inputs.digest()
+---
+[
+  3,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  8,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0
+]
+


### PR DESCRIPTION
## Summary
- add insta snapshot coverage for the LFSR public input digest and codec edge cases
- verify trace, boundary, and transition determinism including tampering failures
- introduce proptest-based fuzzing over small seeds and lengths

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e2e088ddf48326aff75ba10366955b