### PR TITLE
Expose AIR exports and add postcard dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +73,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -130,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +243,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -262,6 +304,29 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -337,6 +402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +469,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -550,9 +637,19 @@ dependencies = [
  "bincode",
  "criterion",
  "insta",
+ "postcard",
  "proptest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -600,6 +697,18 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -651,6 +760,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +796,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ parallel = []
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+postcard = { version = "1", features = ["use-std"] }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/air/types.rs
+++ b/src/air/types.rs
@@ -364,14 +364,11 @@ impl TraceData {
             BoundaryAt::Last => column.len().saturating_sub(1),
             BoundaryAt::Row(r) => r,
         };
-        column
-            .get(row)
-            .copied()
-            .ok_or_else(|| AirError::BoundaryViolation {
-                column: ix,
-                boundary,
-                detail: "boundary outside trace length",
-            })
+        column.get(row).copied().ok_or(AirError::BoundaryViolation {
+            column: ix,
+            boundary,
+            detail: "boundary outside trace length",
+        })
     }
 
     /// Serialises a column into canonical little-endian field element bytes.

--- a/src/fft/lde.rs
+++ b/src/fft/lde.rs
@@ -273,7 +273,7 @@ impl LowDegreeExtender {
         let chunk_size = self.params.chunking.chunk_size;
         assert!(chunk_size > 0, "chunk size must be non-zero");
         let total_rows = self.extended_rows();
-        let total_chunks = (total_rows + chunk_size - 1) / chunk_size;
+        let total_chunks = total_rows.div_ceil(chunk_size);
 
         let mut assignments = Vec::new();
 
@@ -289,7 +289,7 @@ impl LowDegreeExtender {
                 }
             }
             ChunkingDeterminism::WorkerMajor => {
-                let chunks_per_worker = (total_chunks + worker_count - 1) / worker_count;
+                let chunks_per_worker = total_chunks.div_ceil(worker_count);
                 let start_chunk = worker_id * chunks_per_worker;
                 let end_chunk = ((worker_id + 1) * chunks_per_worker).min(total_chunks);
                 for chunk_idx in start_chunk..end_chunk {

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -366,7 +366,6 @@ impl Radix2Fft {
     /// Creates a plan for the provided domain size and element ordering.
     pub fn new(log2_size: usize, ordering: Radix2Ordering) -> Self {
         assert!(RADIX2_FFT_BUTTERFLIES_PER_TILE.is_power_of_two());
-        assert!(RADIX2_FFT_BUTTERFLIES_PER_TILE > 0);
         Self {
             domain: Radix2Domain::new(log2_size, ordering),
         }

--- a/src/field/prime_field.rs
+++ b/src/field/prime_field.rs
@@ -148,7 +148,7 @@ impl FieldElement {
         let mut acc = FieldElement::ONE;
         for i in 0..64 {
             let bit = (exponent >> i) & 1;
-            let mask = (bit as u64).wrapping_neg();
+            let mask = bit.wrapping_neg();
             let candidate = acc.mul_internal(&base);
             let acc_val = (acc.0 & !mask) | (candidate.0 & mask);
             acc = FieldElement(acc_val);

--- a/src/fri/batch.rs
+++ b/src/fri/batch.rs
@@ -12,29 +12,17 @@ use super::pseudo_blake3;
 use super::types::{FriError, FriSecurityLevel, FriTranscriptSeed};
 
 /// Seed shared across the batch, typically derived from a transcript challenge.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct BatchSeed {
     /// Raw bytes sourced from the Fiat-Shamir transcript.
     pub bytes: [u8; 32],
 }
 
-impl Default for BatchSeed {
-    fn default() -> Self {
-        Self { bytes: [0u8; 32] }
-    }
-}
-
 /// Aggregated digest binding all batched openings.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct BatchDigest {
     /// Canonical digest over the ordered batch openings.
     pub bytes: [u8; 32],
-}
-
-impl Default for BatchDigest {
-    fn default() -> Self {
-        Self { bytes: [0u8; 32] }
-    }
 }
 
 /// Describes a query position inside a batched verification request.
@@ -47,7 +35,7 @@ pub struct BatchQueryPosition {
 }
 
 /// Declarative container describing the inputs to a batched FRI verification.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FriBatch {
     /// Proofs participating in the batch.
     pub proofs: Vec<FriProof>,
@@ -57,17 +45,6 @@ pub struct FriBatch {
     pub query_positions: Vec<BatchQueryPosition>,
     /// Digest aggregating all openings in the order imposed by the transcript.
     pub aggregate_digest: BatchDigest,
-}
-
-impl Default for FriBatch {
-    fn default() -> Self {
-        Self {
-            proofs: Vec::new(),
-            joint_seed: BatchSeed::default(),
-            query_positions: Vec::new(),
-            aggregate_digest: BatchDigest::default(),
-        }
-    }
 }
 
 impl FriBatch {

--- a/src/hash/merkle.rs
+++ b/src/hash/merkle.rs
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn build_path_verify_roundtrip_ok() {
-        let payloads = vec![
+        let payloads = [
             encode_leaf(&[1, 2, 3]),
             encode_leaf(&[4, 5, 6, 7]),
             encode_leaf(&[]),
@@ -337,7 +337,7 @@ mod tests {
 
     #[test]
     fn verify_fails_on_wrong_sibling_order() {
-        let payloads = vec![
+        let payloads = [
             encode_leaf(&[1, 2, 3, 4]),
             encode_leaf(&[5, 6, 7, 8]),
             encode_leaf(&[9, 10, 11, 12]),
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn verify_fails_on_bad_index_byte() {
-        let payloads = vec![encode_leaf(&[42]), encode_leaf(&[43])];
+        let payloads = [encode_leaf(&[42]), encode_leaf(&[43])];
         let tree = Blake3MerkleTree::from_leaves(payloads.iter()).expect("tree");
         let mut path = tree.open(0).expect("path");
         path[0].index = MerkleIndex(2);
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn verify_fails_on_bad_padding() {
         let leaf = encode_leaf(&[42]);
-        let path = vec![MerklePathElement {
+        let path = [MerklePathElement {
             index: MerkleIndex(0),
             siblings: [[0xFF; DIGEST_SIZE]],
         }];
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn right_padding_with_empty_constant_ok() {
         assert_eq!(EMPTY_DIGEST, hash(b"RPP-MERKLE-EMPTY\0").into_bytes());
-        let payloads = vec![
+        let payloads = [
             encode_leaf(&[1]),
             encode_leaf(&[2]),
             encode_leaf(&[3]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
 //! Core library entry point for the `rpp-stark` proof system.
@@ -26,6 +26,21 @@ use proof::aggregation::BatchVerificationOutcome;
 use proof::public_inputs::PublicInputs;
 use proof::{BatchProofRecord, ProofKind};
 use utils::serialization::{ProofBytes, WitnessBlob};
+
+pub use air::example::{
+    lfsr::PublicInputs as LfsrPublicInputs, LfsrAir as ExampleLfsrAir,
+    LfsrTraceBuilder as ExampleLfsrTraceBuilder,
+};
+pub use air::traits::{
+    Air as AirContract, BoundaryBuilder as AirBoundaryBuilder,
+    BoundaryConstraint as AirBoundaryConstraint, Constraint as AirConstraint,
+    Evaluator as AirEvaluator, PolyExpr as AirPolyExpr, PublicInputsCodec as AirPublicInputsCodec,
+    TraceBuilder as AirTraceBuilder,
+};
+pub use air::types::{
+    AirError, BoundaryAt, DegreeBounds, LdeOrder, PublicFieldMeta, PublicFieldType, PublicSpec,
+    SerKind, TraceColMeta, TraceData, TraceRole, TraceSchema,
+};
 
 /// Result type used throughout the library to surface deterministic errors.
 pub type StarkResult<T> = core::result::Result<T, StarkError>;

--- a/src/params/ser.rs
+++ b/src/params/ser.rs
@@ -35,7 +35,7 @@ use super::StarkParams;
 ///
 /// The layout intentionally avoids padding and ensures that byte-for-byte
 /// equality implies identical parameter sets.
-
+///
 /// Serialisation error kind.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SerKind {

--- a/src/vrf/mod.rs
+++ b/src/vrf/mod.rs
@@ -379,6 +379,9 @@ impl VrfTestPlan {
     ];
 }
 
+/// Alias for the normalized VRF output bytes.
+pub type VrfOutput = [u8; VrfOutputNormalizationSpec::OUTPUT_LENGTH];
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -405,6 +408,3 @@ pub mod tests {
         assert_eq!(err, VrfVerificationFailure::ErrVrfTranscriptOrder);
     }
 }
-
-/// Alias for the normalized VRF output bytes.
-pub type VrfOutput = [u8; VrfOutputNormalizationSpec::OUTPUT_LENGTH];

--- a/src/vrf/pq.rs
+++ b/src/vrf/pq.rs
@@ -230,16 +230,12 @@ pub fn normalize_output(coeffs: &[u64]) -> [u8; 32] {
 }
 
 fn rejection_sample_32(reader: &mut OutputReader) -> [u8; 32] {
-    // Target space is 2^256; the rejection loop is implemented generically even though
-    // every 32-byte value is valid. The structure mirrors the specification and allows
-    // future tightening of the range without touching the logic.
-    loop {
-        let mut candidate = [0u8; 32];
-        reader.fill(&mut candidate);
-        // With a full 2^256 target the rejection bound equals the entire space, therefore
-        // every candidate is accepted.
-        return candidate;
-    }
+    // Target space is 2^256; every 32-byte value is currently accepted. The helper
+    // retains the structure described in the specification but avoids the degenerate
+    // loop that never iterated.
+    let mut candidate = [0u8; 32];
+    reader.fill(&mut candidate);
+    candidate
 }
 
 fn select_primitive_root(degree: u32) -> u64 {

--- a/tests/air_end_to_end.rs
+++ b/tests/air_end_to_end.rs
@@ -6,9 +6,9 @@ use rpp_stark::air::composition::{
 use rpp_stark::air::example::{LfsrAir, LfsrPublicInputs};
 use rpp_stark::air::traits::{Air, TraceBuilder};
 use rpp_stark::air::types::TraceRole;
+use rpp_stark::fft::lde::{LowDegreeExtender, PROFILE_X8};
 use rpp_stark::field::prime_field::{CanonicalSerialize, FieldElementOps};
 use rpp_stark::field::FieldElement;
-use rpp_stark::fft::lde::{LowDegreeExtender, PROFILE_X8};
 use rpp_stark::fri::{fri_prove, fri_verify, FriError, FriProof};
 use rpp_stark::hash::merkle::DIGEST_SIZE;
 use rpp_stark::merkle::{DeterministicMerkleHasher, Digest, Leaf, MerkleCommit, MerkleTree};
@@ -76,7 +76,9 @@ fn fri_pipeline_rejects_alpha_tampering() {
 
     let err = fri_verify(&tampered, &fixture.params, &mut verifier_transcript)
         .expect_err("tampered alpha must be rejected");
-    assert!(matches!(err, FriError::InvalidStructure(reason) if reason == "fold challenge mismatch"));
+    assert!(
+        matches!(err, FriError::InvalidStructure(reason) if reason == "fold challenge mismatch")
+    );
 }
 
 #[test]
@@ -144,7 +146,9 @@ fn fri_pipeline_rejects_trace_root_tampering() {
 
     let err = fri_verify(&fixture.proof, &fixture.params, &mut transcript)
         .expect_err("tampered trace root must be rejected");
-    assert!(matches!(err, FriError::InvalidStructure(reason) if reason == "fold challenge mismatch"));
+    assert!(
+        matches!(err, FriError::InvalidStructure(reason) if reason == "fold challenge mismatch")
+    );
 }
 
 fn build_fixture() -> LfsrFriFixture {
@@ -174,12 +178,11 @@ fn build_fixture() -> LfsrFriFixture {
     let extended_trace = extender.extend_trace(&trace_column);
 
     let trace_leaves = pack_leaves(&extended_trace, params.merkle().leaf_width as usize);
-    let (trace_root, _trace_aux) =
-        <MerkleTree<DeterministicMerkleHasher> as MerkleCommit>::commit(
-            &params,
-            trace_leaves.into_iter(),
-        )
-        .expect("trace commitment");
+    let (trace_root, _trace_aux) = <MerkleTree<DeterministicMerkleHasher> as MerkleCommit>::commit(
+        &params,
+        trace_leaves.into_iter(),
+    )
+    .expect("trace commitment");
 
     let domain_size = 1usize << params.fri().domain_log2 as usize;
     let evaluations = transition_evaluations(&trace_column, domain_size);
@@ -201,10 +204,7 @@ fn build_fixture() -> LfsrFriFixture {
         )
         .expect("absorb public inputs");
     transcript
-        .absorb_digest(
-            TranscriptLabel::TraceRoot,
-            &digest_from_merkle(&trace_root),
-        )
+        .absorb_digest(TranscriptLabel::TraceRoot, &digest_from_merkle(&trace_root))
         .expect("absorb trace root");
     let trace_challenge = transcript
         .challenge_field(TranscriptLabel::TraceChallengeA)
@@ -276,7 +276,11 @@ fn transition_evaluations(trace_column: &[FieldElement], domain_size: usize) -> 
 
 fn pack_leaves(values: &[FieldElement], leaf_width: usize) -> Vec<Leaf> {
     assert!(leaf_width > 0, "leaf width must be positive");
-    assert_eq!(values.len() % leaf_width, 0, "evaluations must align with leaf width");
+    assert_eq!(
+        values.len() % leaf_width,
+        0,
+        "evaluations must align with leaf width"
+    );
     values
         .chunks(leaf_width)
         .map(|chunk| {

--- a/tests/fri_end_to_end.rs
+++ b/tests/fri_end_to_end.rs
@@ -2,12 +2,14 @@ use insta::assert_snapshot;
 use proptest::prelude::*;
 use rpp_stark::field::prime_field::FieldElementOps;
 use rpp_stark::field::FieldElement;
-use rpp_stark::fri::{DeepOodsProof, FriProof, FriSecurityLevel, FriTranscriptSeed, FriVerifier};
 use rpp_stark::fri::types::FriError;
+use rpp_stark::fri::{DeepOodsProof, FriProof, FriSecurityLevel, FriTranscriptSeed, FriVerifier};
 use rpp_stark::hash::{pseudo_blake3, FiatShamirChallengeRules, PseudoBlake3Xof};
 
 fn sample_evaluations() -> Vec<FieldElement> {
-    (0..512).map(|i| FieldElement::from((i as u64) + 1)).collect()
+    (0..512)
+        .map(|i| FieldElement::from((i as u64) + 1))
+        .collect()
 }
 
 fn sample_seed() -> FriTranscriptSeed {
@@ -30,12 +32,7 @@ fn hex_bytes(bytes: &[u8]) -> String {
 fn attach_deep_payload(base: &FriProof) -> FriProof {
     let deep = DeepOodsProof {
         point: FieldElement::from(123u64),
-        evaluations: base
-            .final_polynomial
-            .iter()
-            .take(8)
-            .cloned()
-            .collect(),
+        evaluations: base.final_polynomial.iter().take(8).cloned().collect(),
     };
 
     FriProof::with_deep_oods(
@@ -207,7 +204,9 @@ fn tampered_layer_root_is_rejected() {
     )
     .expect_err("tampering should be detected");
 
-    assert!(matches!(err, FriError::InvalidStructure(message) if message == "fold challenge mismatch"));
+    assert!(
+        matches!(err, FriError::InvalidStructure(message) if message == "fold challenge mismatch")
+    );
 }
 
 #[test]
@@ -229,7 +228,9 @@ fn tampered_fold_challenge_is_rejected() {
     )
     .expect_err("tampering should be detected");
 
-    assert!(matches!(err, FriError::InvalidStructure(message) if message == "fold challenge mismatch"));
+    assert!(
+        matches!(err, FriError::InvalidStructure(message) if message == "fold challenge mismatch")
+    );
 }
 
 proptest! {


### PR DESCRIPTION
## Summary
- switch the crate to `#![forbid(unsafe_code)]` and re-export AIR contracts for downstream users
- add the postcard serialization crate and refresh the lockfile
- tidy supporting modules and tests (derive defaults, simplify helpers, and formatting tweaks)

## Testing
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68e2ea0745b88326844715647f87299e