### PR TITLE
Introduce canonical proof types module

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,7 @@
 
 use crate::hash::Hasher;
 use crate::utils::serialization::DigestBytes;
+use serde::{Deserialize, Serialize};
 
 /// Fixed domain separator used when hashing the parameter layout into the
 /// [`ParamDigest`]. The tag is ASCII encoded and **must** be prepended to the
@@ -23,7 +24,7 @@ pub const PARAM_DIGEST_DOMAIN_TAG: &[u8; 13] = b"RPP-PARAMS-V1";
 pub const PI_DIGEST_DOMAIN_TAG: &[u8; 9] = b"RPP-PI-V1";
 
 /// Identifier describing a configuration profile.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProfileId(pub u8);
 
 impl ProfileId {
@@ -46,7 +47,7 @@ pub const PROFILE_HISEC: ProfileId = ProfileId(2);
 pub const PROFILE_THROUGHPUT: ProfileId = ProfileId(3);
 
 /// Identifier describing the base field of the AIR.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FieldId(pub u8);
 
 impl FieldId {
@@ -60,7 +61,7 @@ impl FieldId {
 pub const FIELD_ID_GOLDILOCKS_64: FieldId = FieldId(1);
 
 /// Identifier describing a Poseidon parameter set.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoseidonParamId(pub DigestBytes);
 
 impl PoseidonParamId {
@@ -77,7 +78,7 @@ impl PoseidonParamId {
 }
 
 /// Identifier describing the Merkle commitment scheme.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MerkleSchemeId(pub DigestBytes);
 
 impl MerkleSchemeId {
@@ -94,7 +95,7 @@ impl MerkleSchemeId {
 }
 
 /// Identifier describing the Fiat-Shamir transcript version.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TranscriptVersionId(pub DigestBytes);
 
 impl TranscriptVersionId {
@@ -111,7 +112,7 @@ impl TranscriptVersionId {
 }
 
 /// Identifier describing the canonical FRI folding plan.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FriPlanId(pub DigestBytes);
 
 impl FriPlanId {
@@ -128,7 +129,7 @@ impl FriPlanId {
 }
 
 /// Identifier describing the AIR specification bound to a proof kind.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AirSpecId(pub DigestBytes);
 
 impl AirSpecId {
@@ -145,7 +146,7 @@ impl AirSpecId {
 }
 
 /// Identifier describing the version of the proof envelope/layout.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProofVersion(pub u8);
 
 impl ProofVersion {
@@ -323,7 +324,7 @@ pub struct ProfileConfig {
 ///   17. `reserved:u16` (currently zero)
 /// * Hash the resulting byte string with BLAKE3.
 /// * The 32-byte output is stored in this wrapper.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParamDigest(pub DigestBytes);
 
 /// Digest binding a single proof's public inputs for deterministic batching.
@@ -333,7 +334,7 @@ pub struct ParamDigest(pub DigestBytes);
 pub struct PiDigest(pub DigestBytes);
 
 /// Common identifiers shared across all profiles.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommonIdentifiers {
     pub field_id: FieldId,
     pub merkle_scheme_id: MerkleSchemeId,

--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -254,11 +254,11 @@ mod tests {
         CommonIdentifiers, ParamDigest, ProfileConfig, ProofSystemConfig, ProofVersion,
         PROFILE_STANDARD_CONFIG,
     };
-    use crate::proof::envelope::{
-        ProofEnvelope, ProofEnvelopeBody, ProofEnvelopeHeader, PROOF_VERSION,
-    };
     use crate::proof::public_inputs::{
         AggregationHeaderV1, ExecutionHeaderV1, PublicInputVersion, PublicInputs, RecursionHeaderV1,
+    };
+    use crate::proof::types::{
+        FriParametersMirror, MerkleProofBundle, Openings, Proof, Telemetry, PROOF_VERSION,
     };
     use crate::proof::verifier::PrecheckedProof;
     use crate::utils::serialization::{DigestBytes, FieldElementBytes, ProofBytes};
@@ -267,7 +267,7 @@ mod tests {
         let profile: ProfileConfig = PROFILE_STANDARD_CONFIG.clone();
         let param_digest = ParamDigest(DigestBytes { bytes: [1u8; 32] });
         let config = ProofSystemConfig {
-            proof_version: ProofVersion(PROOF_VERSION),
+            proof_version: ProofVersion(PROOF_VERSION as u8),
             profile: profile.clone(),
             param_digest: param_digest.clone(),
         };
@@ -346,33 +346,35 @@ mod tests {
 
     fn dummy_prechecked_proof() -> PrecheckedProof {
         PrecheckedProof {
-            envelope: ProofEnvelope {
-                header: ProofEnvelopeHeader {
-                    proof_version: PROOF_VERSION,
-                    proof_kind: crate::config::ProofKind::Tx,
-                    param_digest: ParamDigest(DigestBytes { bytes: [7u8; 32] }),
-                    air_spec_id: crate::config::AIR_SPEC_IDS_V1.tx.clone(),
-                    public_inputs: Vec::new(),
-                    commitment_digest: DigestBytes { bytes: [8u8; 32] },
-                    header_length: 0,
-                    body_length: 0,
-                },
-                body: ProofEnvelopeBody {
+            proof: Proof {
+                version: PROOF_VERSION,
+                kind: crate::config::ProofKind::Tx,
+                param_digest: ParamDigest(DigestBytes { bytes: [7u8; 32] }),
+                air_spec_id: crate::config::AIR_SPEC_IDS_V1.tx.clone(),
+                public_inputs: Vec::new(),
+                commitment_digest: DigestBytes { bytes: [8u8; 32] },
+                merkle: MerkleProofBundle {
                     core_root: [0u8; 32],
                     aux_root: [0u8; 32],
                     fri_layer_roots: Vec::new(),
-                    ood_openings: Vec::new(),
-                    fri_proof: crate::fri::FriProof::new(
-                        crate::fri::FriSecurityLevel::Standard,
-                        1,
-                        Vec::new(),
-                        Vec::new(),
-                        Vec::new(),
-                        [0u8; 32],
-                        Vec::new(),
-                    )
-                    .expect("empty fri proof"),
-                    fri_parameters: crate::proof::envelope::FriParametersMirror::default(),
+                },
+                openings: Openings {
+                    out_of_domain: Vec::new(),
+                },
+                fri_proof: crate::fri::FriProof::new(
+                    crate::fri::FriSecurityLevel::Standard,
+                    1,
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    [0u8; 32],
+                    Vec::new(),
+                )
+                .expect("empty fri proof"),
+                telemetry: Telemetry {
+                    header_length: 0,
+                    body_length: 0,
+                    fri_parameters: FriParametersMirror::default(),
                     integrity_digest: DigestBytes { bytes: [9u8; 32] },
                 },
             },

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -12,6 +12,7 @@ pub mod errors;
 pub mod prover;
 pub mod public_inputs;
 pub mod transcript;
+pub mod types;
 pub mod verifier;
 
 pub use aggregation::{BatchProofRecord, BatchVerificationOutcome, BlockContext};

--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -1,0 +1,197 @@
+use crate::config::{AirSpecId, ParamDigest, ProofKind};
+use crate::fri::FriProof;
+use crate::utils::serialization::DigestBytes;
+use serde::{Deserialize, Serialize};
+
+/// Canonical proof version implemented by this crate.
+pub const PROOF_VERSION: u16 = 1;
+
+/// Fully decoded proof container mirroring the authoritative specification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Proof {
+    /// Declared proof version (currently `1`).
+    #[serde(with = "proof_version_codec")]
+    pub version: u16,
+    /// Canonical proof kind stored in the envelope header.
+    #[serde(with = "proof_kind_codec")]
+    pub kind: ProofKind,
+    /// Parameter digest binding configuration knobs.
+    pub param_digest: ParamDigest,
+    /// AIR specification identifier for the proof kind.
+    pub air_spec_id: AirSpecId,
+    /// Canonical public input encoding.
+    pub public_inputs: Vec<u8>,
+    /// Digest binding commitments prior to parsing the body.
+    pub commitment_digest: DigestBytes,
+    /// Merkle commitment bundle for core, auxiliary and FRI layers.
+    pub merkle: MerkleProofBundle,
+    /// Out-of-domain opening payloads.
+    pub openings: Openings,
+    /// FRI proof payload accompanying the envelope.
+    pub fri_proof: FriProof,
+    /// Telemetry frame describing declared lengths and digests.
+    pub telemetry: Telemetry,
+}
+
+/// Merkle commitment bundle covering core, auxiliary and FRI layer roots.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MerkleProofBundle {
+    /// Core commitment root.
+    pub core_root: [u8; 32],
+    /// Auxiliary commitment root (zero if absent).
+    pub aux_root: [u8; 32],
+    /// FRI layer roots emitted during the prover pipeline.
+    pub fri_layer_roots: Vec<[u8; 32]>,
+}
+
+/// Out-of-domain opening container.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Openings {
+    /// Individual out-of-domain openings.
+    pub out_of_domain: Vec<OutOfDomainOpening>,
+}
+
+/// Telemetry frame exposing declared lengths and FRI parameters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Telemetry {
+    /// Declared header length (used for sanity checks).
+    pub header_length: u32,
+    /// Declared body length (includes integrity digest).
+    pub body_length: u32,
+    /// Optional mirror of the FRI parameters encoded in the proof body.
+    pub fri_parameters: FriParametersMirror,
+    /// Integrity digest covering the header bytes and body payload.
+    pub integrity_digest: DigestBytes,
+}
+
+/// Structured verification report pairing a decoded proof with the outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifyReport {
+    /// Fully decoded proof container.
+    pub proof: Proof,
+    /// Optional verification error captured during decoding or checks.
+    pub error: Option<VerifyError>,
+}
+
+/// Errors surfaced while decoding or encoding a proof envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VerifyError {
+    /// The proof version encoded in the header is not supported.
+    UnsupportedVersion(u16),
+    /// The proof kind byte does not match the canonical ordering.
+    UnknownProofKind(u8),
+    /// Declared header length does not match the observed byte count.
+    HeaderLengthMismatch { declared: u32, actual: u32 },
+    /// Declared body length does not match the observed byte count.
+    BodyLengthMismatch { declared: u32, actual: u32 },
+    /// The buffer ended prematurely while parsing a section.
+    UnexpectedEndOfBuffer(String),
+    /// Integrity digest recomputed from the payload disagreed with the header.
+    IntegrityDigestMismatch,
+    /// The FRI section contained invalid structure.
+    InvalidFriSection(String),
+    /// Encountered a non-canonical field element while decoding.
+    NonCanonicalFieldElement,
+}
+
+/// Mirror of the FRI parameters stored inside the proof body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FriParametersMirror {
+    /// Folding factor (fixed to two in the current implementation).
+    pub fold: u8,
+    /// Degree of the cap polynomial.
+    pub cap_degree: u16,
+    /// Size of the cap commitment.
+    pub cap_size: u32,
+    /// Query budget consumed during verification.
+    pub query_budget: u16,
+}
+
+impl Default for FriParametersMirror {
+    fn default() -> Self {
+        Self {
+            fold: 2,
+            cap_degree: 0,
+            cap_size: 0,
+            query_budget: 0,
+        }
+    }
+}
+
+/// Out-of-domain opening description stored in the proof body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutOfDomainOpening {
+    /// OOD evaluation point.
+    pub point: [u8; 32],
+    /// Core trace evaluations at that point.
+    pub core_values: Vec<[u8; 32]>,
+    /// Auxiliary evaluations.
+    pub aux_values: Vec<[u8; 32]>,
+    /// Composition polynomial evaluation.
+    pub composition_value: [u8; 32],
+}
+
+mod proof_kind_codec {
+    use super::ProofKind;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &ProofKind, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(encode(*value))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ProofKind, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let byte = u8::deserialize(deserializer)?;
+        decode(byte).map_err(serde::de::Error::custom)
+    }
+
+    fn encode(kind: ProofKind) -> u8 {
+        match kind {
+            ProofKind::Tx => 0,
+            ProofKind::State => 1,
+            ProofKind::Pruning => 2,
+            ProofKind::Uptime => 3,
+            ProofKind::Consensus => 4,
+            ProofKind::Identity => 5,
+            ProofKind::Aggregation => 6,
+            ProofKind::VRF => 7,
+        }
+    }
+
+    fn decode(byte: u8) -> Result<ProofKind, &'static str> {
+        Ok(match byte {
+            0 => ProofKind::Tx,
+            1 => ProofKind::State,
+            2 => ProofKind::Pruning,
+            3 => ProofKind::Uptime,
+            4 => ProofKind::Consensus,
+            5 => ProofKind::Identity,
+            6 => ProofKind::Aggregation,
+            7 => ProofKind::VRF,
+            _ => return Err("unknown proof kind"),
+        })
+    }
+}
+
+mod proof_version_codec {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &u16, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u16(*value)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u16, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        u16::deserialize(deserializer)
+    }
+}

--- a/src/utils/serialization.rs
+++ b/src/utils/serialization.rs
@@ -5,6 +5,8 @@
 //! but come with extensive documentation that mirrors the constraints imposed
 //! by the proof formats documented elsewhere.
 
+use serde::{Deserialize, Serialize};
+
 /// Wrapper around proof bytes ensuring explicit conversions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProofBytes {
@@ -32,14 +34,14 @@ pub struct WitnessBlob<'a> {
 }
 
 /// Fixed width digest byte array used throughout the documentation layer.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DigestBytes {
     /// Raw digest bytes (e.g. BLAKE3, SHA-256 etc.).
     pub bytes: [u8; 32],
 }
 
 /// Wrapper around field element encodings.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FieldElementBytes {
     /// Little endian encoding of a field element.
     pub bytes: [u8; 32],


### PR DESCRIPTION
## Summary
- add a proof metadata module defining the canonical Proof layout with serde support
- refactor envelope, prover, verifier, and helpers to consume the new structures
- derive serde support for supporting config and serialization wrappers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2fb26b2c8832692e2cf47c25751fb