### PR TITLE
Refactor proof module exports and serialization helpers

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -10,7 +10,7 @@ use rpp_stark::config::{
 use rpp_stark::field::FieldElement;
 use rpp_stark::fri::{FriProof, FriSecurityLevel};
 use rpp_stark::hash::{hash, Hasher, OutputReader};
-use rpp_stark::proof::envelope::{
+use rpp_stark::proof::ser::{
     compute_commitment_digest, compute_integrity_digest, serialize_public_inputs,
 };
 use rpp_stark::proof::public_inputs::{ExecutionHeaderV1, PublicInputVersion, PublicInputs};

--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -10,10 +10,10 @@ use rpp_stark::config::{
 use rpp_stark::field::FieldElement;
 use rpp_stark::fri::{FriProof, FriSecurityLevel};
 use rpp_stark::hash::{hash, Hasher, OutputReader};
+use rpp_stark::proof::public_inputs::{ExecutionHeaderV1, PublicInputVersion, PublicInputs};
 use rpp_stark::proof::ser::{
     compute_commitment_digest, compute_integrity_digest, serialize_public_inputs,
 };
-use rpp_stark::proof::public_inputs::{ExecutionHeaderV1, PublicInputVersion, PublicInputs};
 use rpp_stark::proof::types::{
     FriParametersMirror, MerkleProofBundle, Openings, OutOfDomainOpening, Proof, Telemetry,
     PROOF_VERSION,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,10 @@ pub mod utils;
 pub mod vrf;
 
 use config::{ProofSystemConfig, ProverContext, VerifierContext};
-use proof::aggregation::BatchVerificationOutcome;
+use proof::aggregation::{BatchProofRecord, BatchVerificationOutcome};
+use proof::errors::VerificationFailure;
 use proof::public_inputs::PublicInputs;
-use proof::{BatchProofRecord, ProofKind};
+use proof::ProofKind;
 use utils::serialization::{ProofBytes, WitnessBlob};
 
 pub use air::example::{
@@ -62,7 +63,7 @@ pub enum VerificationVerdict {
     /// Proof accepted after all checks.
     Accept,
     /// Proof rejected with a documented failure class.
-    Reject(proof::VerificationFailure),
+    Reject(VerificationFailure),
 }
 
 /// Generates a proof for the specified [`ProofKind`].

--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -5,8 +5,8 @@
 
 use crate::config::{ProofSystemConfig, VerifierContext};
 use crate::hash::Hasher;
-use crate::proof::envelope::{map_public_to_config_kind, serialize_public_inputs};
 use crate::proof::public_inputs::ProofKind;
+use crate::proof::ser::{map_public_to_config_kind, serialize_public_inputs};
 use crate::proof::transcript::TranscriptBlockContext;
 use crate::utils::serialization::ProofBytes;
 

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -9,10 +9,9 @@ use std::convert::TryInto;
 
 use crate::config::{AirSpecId, ParamDigest, ProofKind};
 use crate::fri::FriProof;
-use crate::hash::Hasher;
-use crate::proof::public_inputs::{
-    AggregationHeaderV1, ExecutionHeaderV1, PublicInputVersion, PublicInputs, RecursionHeaderV1,
-    VrfHeaderV1,
+use crate::proof::ser::{
+    compute_commitment_digest, compute_integrity_digest, decode_proof_kind, deserialize_fri_proof,
+    encode_proof_kind, serialize_fri_proof,
 };
 use crate::proof::types::{
     FriParametersMirror, MerkleProofBundle, Openings, OutOfDomainOpening, Proof, Telemetry,
@@ -282,162 +281,6 @@ impl OutOfDomainOpening {
     }
 }
 
-/// Computes the commitment digest over core, auxiliary and FRI layer roots.
-pub fn compute_commitment_digest(
-    core_root: &[u8; 32],
-    aux_root: &[u8; 32],
-    fri_layer_roots: &[[u8; 32]],
-) -> [u8; 32] {
-    let mut hasher = Hasher::new();
-    hasher.update(core_root);
-    hasher.update(aux_root);
-    for root in fri_layer_roots {
-        hasher.update(root);
-    }
-    *hasher.finalize().as_bytes()
-}
-
-/// Computes the integrity digest over the header bytes and body payload.
-pub fn compute_integrity_digest(header_bytes: &[u8], body_payload: &[u8]) -> [u8; 32] {
-    let mut hasher = Hasher::new();
-    hasher.update(header_bytes);
-    hasher.update(body_payload);
-    *hasher.finalize().as_bytes()
-}
-
-/// Serialises the public inputs using the canonical layout.
-pub fn serialize_public_inputs(inputs: &PublicInputs<'_>) -> Vec<u8> {
-    fn version_byte(version: PublicInputVersion) -> u8 {
-        match version {
-            PublicInputVersion::V1 => 1,
-        }
-    }
-
-    match inputs {
-        PublicInputs::Execution { header, body } => {
-            let ExecutionHeaderV1 {
-                version,
-                program_digest,
-                trace_length,
-                trace_width,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.extend_from_slice(&program_digest.bytes);
-            buffer.extend_from_slice(&trace_length.to_le_bytes());
-            buffer.extend_from_slice(&trace_width.to_le_bytes());
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-        PublicInputs::Aggregation { header, body } => {
-            let AggregationHeaderV1 {
-                version,
-                circuit_digest,
-                leaf_count,
-                root_digest,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.extend_from_slice(&circuit_digest.bytes);
-            buffer.extend_from_slice(&leaf_count.to_le_bytes());
-            buffer.extend_from_slice(&root_digest.bytes);
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-        PublicInputs::Recursion { header, body } => {
-            let RecursionHeaderV1 {
-                version,
-                depth,
-                boundary_digest,
-                recursion_seed,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.push(*depth);
-            buffer.extend_from_slice(&boundary_digest.bytes);
-            buffer.extend_from_slice(&recursion_seed.bytes);
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-        PublicInputs::Vrf { header, body } => {
-            let VrfHeaderV1 {
-                version,
-                public_key_commit,
-                prf_param_digest,
-                rlwe_param_id,
-                vrf_param_id,
-                transcript_version_id,
-                field_id,
-                context_digest,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.extend_from_slice(&public_key_commit.bytes);
-            buffer.extend_from_slice(&prf_param_digest.bytes);
-            buffer.extend_from_slice(rlwe_param_id.as_bytes());
-            buffer.extend_from_slice(vrf_param_id.as_bytes());
-            let tv = transcript_version_id.clone().bytes();
-            buffer.extend_from_slice(&tv.bytes);
-            buffer.extend_from_slice(&field_id.to_le_bytes());
-            buffer.extend_from_slice(&context_digest.bytes);
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-    }
-}
-
-/// Maps a public-input proof kind to the global configuration ordering.
-pub fn map_public_to_config_kind(kind: crate::proof::public_inputs::ProofKind) -> ProofKind {
-    use crate::proof::public_inputs::ProofKind as PublicKind;
-    match kind {
-        PublicKind::Execution => ProofKind::Tx,
-        PublicKind::Aggregation => ProofKind::Aggregation,
-        PublicKind::Recursion => ProofKind::State,
-        PublicKind::VrfPostQuantum => ProofKind::VRF,
-    }
-}
-
-fn encode_proof_kind(kind: ProofKind) -> u8 {
-    match kind {
-        ProofKind::Tx => 0,
-        ProofKind::State => 1,
-        ProofKind::Pruning => 2,
-        ProofKind::Uptime => 3,
-        ProofKind::Consensus => 4,
-        ProofKind::Identity => 5,
-        ProofKind::Aggregation => 6,
-        ProofKind::VRF => 7,
-    }
-}
-
-fn decode_proof_kind(byte: u8) -> Result<ProofKind, VerifyError> {
-    Ok(match byte {
-        0 => ProofKind::Tx,
-        1 => ProofKind::State,
-        2 => ProofKind::Pruning,
-        3 => ProofKind::Uptime,
-        4 => ProofKind::Consensus,
-        5 => ProofKind::Identity,
-        6 => ProofKind::Aggregation,
-        7 => ProofKind::VRF,
-        other => return Err(VerifyError::UnknownProofKind(other)),
-    })
-}
-
-fn serialize_fri_proof(proof: &FriProof) -> Vec<u8> {
-    proof
-        .to_bytes()
-        .expect("FRI proofs embedded in envelopes must be valid")
-}
-
-fn deserialize_fri_proof(bytes: &[u8]) -> Result<FriProof, VerifyError> {
-    FriProof::from_bytes(bytes).map_err(|_| VerifyError::InvalidFriSection("fri_proof".to_string()))
-}
-
 /// Thin cursor helper used by the serializer/deserializer.
 struct Cursor<'a> {
     bytes: &'a [u8],
@@ -545,7 +388,7 @@ mod tests {
             header: header.clone(),
             body: &body_bytes,
         };
-        let public_input_bytes = serialize_public_inputs(&public_inputs);
+        let public_input_bytes = crate::proof::ser::serialize_public_inputs(&public_inputs);
 
         let merkle = MerkleProofBundle {
             core_root,

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -7,11 +7,14 @@
 
 use std::convert::TryInto;
 
-use crate::config::{AirSpecId, ParamDigest, ProofKind};
+use crate::config::{AirSpecId, ParamDigest};
+#[cfg(test)]
 use crate::fri::FriProof;
+pub use crate::proof::ser::{
+    compute_commitment_digest, compute_integrity_digest, serialize_public_inputs,
+};
 use crate::proof::ser::{
-    compute_commitment_digest, compute_integrity_digest, decode_proof_kind, deserialize_fri_proof,
-    encode_proof_kind, serialize_fri_proof,
+    decode_proof_kind, deserialize_fri_proof, encode_proof_kind, serialize_fri_proof,
 };
 use crate::proof::types::{
     FriParametersMirror, MerkleProofBundle, Openings, OutOfDomainOpening, Proof, Telemetry,

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -1,20 +1,42 @@
-//! Proof generation and verification subsystem.
+//! # Proof module overview
 //!
-//! This module hierarchy documents the contracts for the complete
-//! proof lifecycle without providing executable logic. Every struct or enum
-//! captures layout, ordering or identifier information required to integrate
-//! with the `rpp-stark` ecosystem.
+//! ```text
+//! proof
+//! ├── types      — canonical data models such as [`types::Proof`]
+//! ├── ser        — serialization helpers binding the stable byte layout
+//! ├── envelope   — deterministic encoding/decoding for [`types::Proof`]
+//! └── verifier   — verification contracts mirroring the specification
+//! ```
+//!
+//! ## Versioning policy
+//!
+//! The [`types::Proof`] container records the canonical proof version and
+//! layout declared by the specification. Minor revisions may extend telemetry or
+//! auxiliary metadata, but the header ordering and byte tags remain stable for
+//! a full major release. Any incompatible change to [`types::Proof`] must bump
+//! the crate's major version and update the documented constants exported by the
+//! `types` module.
+//!
+//! ## Compatibility guarantees
+//!
+//! Proof builders and verifiers are expected to treat the structure described by
+//! [`types::Proof`] as authoritative. New fields are appended in a
+//! backward-compatible manner and always guarded by explicit length prefixes.
+//! Consumers can therefore safely decode envelopes emitted by older minor
+//! releases while rejecting payloads that advertise an unsupported `version`.
 
-pub mod aggregation;
-pub mod api;
 pub mod envelope;
-pub mod errors;
-pub mod prover;
-pub mod public_inputs;
-pub mod transcript;
+pub mod ser;
 pub mod types;
 pub mod verifier;
 
-pub use aggregation::{BatchProofRecord, BatchVerificationOutcome, BlockContext};
-pub use errors::VerificationFailure;
+pub(crate) mod aggregation;
+pub(crate) mod api;
+pub(crate) mod errors;
+pub mod prover;
+pub mod public_inputs;
+pub mod transcript;
+
 pub use public_inputs::ProofKind;
+pub use types::{Openings, Proof, Telemetry, VerifyError, VerifyReport};
+pub use verifier::verify_proof_bytes as verify;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -32,11 +32,12 @@ pub mod verifier;
 
 pub(crate) mod aggregation;
 pub(crate) mod api;
-pub(crate) mod errors;
+pub mod errors;
 pub mod prover;
 pub mod public_inputs;
 pub mod transcript;
 
+pub use errors::VerificationFailure;
 pub use public_inputs::ProofKind;
 pub use types::{Openings, Proof, Telemetry, VerifyError, VerifyReport};
 pub use verifier::verify_proof_bytes as verify;

--- a/src/proof/prover.rs
+++ b/src/proof/prover.rs
@@ -15,10 +15,11 @@ use crate::config::{
 use crate::field::FieldElement;
 use crate::fri::{FriError, FriProof, FriSecurityLevel};
 use crate::hash::Hasher;
-use crate::proof::envelope::{
-    compute_commitment_digest, map_public_to_config_kind, serialize_public_inputs,
-};
 use crate::proof::public_inputs::PublicInputs;
+use crate::proof::ser::{
+    compute_commitment_digest, compute_integrity_digest, map_public_to_config_kind,
+    serialize_public_inputs,
+};
 use crate::proof::transcript::{Transcript, TranscriptBlockContext, TranscriptHeader};
 use crate::proof::types::{
     FriParametersMirror, MerkleProofBundle, Openings, OutOfDomainOpening, Proof, Telemetry,
@@ -169,8 +170,7 @@ pub fn build_envelope(
     proof.telemetry.body_length = (body_payload.len() + 32) as u32;
     proof.telemetry.header_length = header_bytes.len() as u32;
 
-    let integrity_digest =
-        crate::proof::envelope::compute_integrity_digest(&header_bytes, &body_payload);
+    let integrity_digest = compute_integrity_digest(&header_bytes, &body_payload);
     proof.telemetry.integrity_digest = DigestBytes {
         bytes: integrity_digest,
     };

--- a/src/proof/ser.rs
+++ b/src/proof/ser.rs
@@ -1,0 +1,171 @@
+//! Serialization helpers for the proof envelope.
+//!
+//! The routines in this module encapsulate the canonical byte-level contracts
+//! shared by the prover and verifier. They intentionally expose pure helpers so
+//! the layout documented by [`super::types::Proof`] can be reused across the
+//! crate without reimplementing framing logic.
+
+use crate::config::ProofKind;
+use crate::fri::FriProof;
+use crate::hash::Hasher;
+use crate::proof::public_inputs::{
+    AggregationHeaderV1, ExecutionHeaderV1, ProofKind as PublicProofKind, PublicInputVersion,
+    PublicInputs, RecursionHeaderV1, VrfHeaderV1,
+};
+use crate::proof::types::VerifyError;
+
+/// Computes the commitment digest over core, auxiliary and FRI layer roots.
+pub fn compute_commitment_digest(
+    core_root: &[u8; 32],
+    aux_root: &[u8; 32],
+    fri_layer_roots: &[[u8; 32]],
+) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(core_root);
+    hasher.update(aux_root);
+    for root in fri_layer_roots {
+        hasher.update(root);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+/// Computes the integrity digest over the header bytes and body payload.
+pub fn compute_integrity_digest(header_bytes: &[u8], body_payload: &[u8]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(header_bytes);
+    hasher.update(body_payload);
+    *hasher.finalize().as_bytes()
+}
+
+/// Serialises the public inputs using the canonical layout.
+pub fn serialize_public_inputs(inputs: &PublicInputs<'_>) -> Vec<u8> {
+    fn version_byte(version: PublicInputVersion) -> u8 {
+        match version {
+            PublicInputVersion::V1 => 1,
+        }
+    }
+
+    match inputs {
+        PublicInputs::Execution { header, body } => {
+            let ExecutionHeaderV1 {
+                version,
+                program_digest,
+                trace_length,
+                trace_width,
+            } = header;
+            let mut buffer = Vec::new();
+            buffer.push(version_byte(*version));
+            buffer.extend_from_slice(&program_digest.bytes);
+            buffer.extend_from_slice(&trace_length.to_le_bytes());
+            buffer.extend_from_slice(&trace_width.to_le_bytes());
+            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
+            buffer.extend_from_slice(body);
+            buffer
+        }
+        PublicInputs::Aggregation { header, body } => {
+            let AggregationHeaderV1 {
+                version,
+                circuit_digest,
+                leaf_count,
+                root_digest,
+            } = header;
+            let mut buffer = Vec::new();
+            buffer.push(version_byte(*version));
+            buffer.extend_from_slice(&circuit_digest.bytes);
+            buffer.extend_from_slice(&leaf_count.to_le_bytes());
+            buffer.extend_from_slice(&root_digest.bytes);
+            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
+            buffer.extend_from_slice(body);
+            buffer
+        }
+        PublicInputs::Recursion { header, body } => {
+            let RecursionHeaderV1 {
+                version,
+                depth,
+                boundary_digest,
+                recursion_seed,
+            } = header;
+            let mut buffer = Vec::new();
+            buffer.push(version_byte(*version));
+            buffer.push(*depth);
+            buffer.extend_from_slice(&boundary_digest.bytes);
+            buffer.extend_from_slice(&recursion_seed.bytes);
+            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
+            buffer.extend_from_slice(body);
+            buffer
+        }
+        PublicInputs::Vrf { header, body } => {
+            let VrfHeaderV1 {
+                version,
+                public_key_commit,
+                prf_param_digest,
+                rlwe_param_id,
+                vrf_param_id,
+                transcript_version_id,
+                field_id,
+                context_digest,
+            } = header;
+            let mut buffer = Vec::new();
+            buffer.push(version_byte(*version));
+            buffer.extend_from_slice(&public_key_commit.bytes);
+            buffer.extend_from_slice(&prf_param_digest.bytes);
+            buffer.extend_from_slice(rlwe_param_id.as_bytes());
+            buffer.extend_from_slice(vrf_param_id.as_bytes());
+            let tv = transcript_version_id.clone().bytes();
+            buffer.extend_from_slice(&tv.bytes);
+            buffer.extend_from_slice(&field_id.to_le_bytes());
+            buffer.extend_from_slice(&context_digest.bytes);
+            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
+            buffer.extend_from_slice(body);
+            buffer
+        }
+    }
+}
+
+/// Maps a public-input proof kind to the global configuration ordering.
+pub fn map_public_to_config_kind(kind: PublicProofKind) -> ProofKind {
+    use crate::proof::public_inputs::ProofKind as PublicKind;
+    match kind {
+        PublicKind::Execution => ProofKind::Tx,
+        PublicKind::Aggregation => ProofKind::Aggregation,
+        PublicKind::Recursion => ProofKind::State,
+        PublicKind::VrfPostQuantum => ProofKind::VRF,
+    }
+}
+
+pub(crate) fn encode_proof_kind(kind: ProofKind) -> u8 {
+    match kind {
+        ProofKind::Tx => 0,
+        ProofKind::State => 1,
+        ProofKind::Pruning => 2,
+        ProofKind::Uptime => 3,
+        ProofKind::Consensus => 4,
+        ProofKind::Identity => 5,
+        ProofKind::Aggregation => 6,
+        ProofKind::VRF => 7,
+    }
+}
+
+pub(crate) fn decode_proof_kind(byte: u8) -> Result<ProofKind, VerifyError> {
+    Ok(match byte {
+        0 => ProofKind::Tx,
+        1 => ProofKind::State,
+        2 => ProofKind::Pruning,
+        3 => ProofKind::Uptime,
+        4 => ProofKind::Consensus,
+        5 => ProofKind::Identity,
+        6 => ProofKind::Aggregation,
+        7 => ProofKind::VRF,
+        other => return Err(VerifyError::UnknownProofKind(other)),
+    })
+}
+
+pub(crate) fn serialize_fri_proof(proof: &FriProof) -> Vec<u8> {
+    proof
+        .to_bytes()
+        .expect("FRI proofs embedded in envelopes must be valid")
+}
+
+pub(crate) fn deserialize_fri_proof(bytes: &[u8]) -> Result<FriProof, VerifyError> {
+    FriProof::from_bytes(bytes).map_err(|_| VerifyError::InvalidFriSection("fri_proof".to_string()))
+}

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -12,11 +12,11 @@ use crate::field::FieldElement;
 use crate::fri::types::{FriError, FriSecurityLevel};
 use crate::fri::FriVerifier;
 use crate::hash::Hasher;
-use crate::proof::envelope::{
+use crate::proof::public_inputs::PublicInputs;
+use crate::proof::ser::{
     compute_commitment_digest, compute_integrity_digest, map_public_to_config_kind,
     serialize_public_inputs,
 };
-use crate::proof::public_inputs::PublicInputs;
 use crate::proof::transcript::{Transcript, TranscriptBlockContext, TranscriptHeader};
 use crate::proof::types::{
     OutOfDomainOpening, Proof, PROOF_ALPHA_VECTOR_LEN, PROOF_MAX_FRI_LAYERS, PROOF_MAX_QUERY_COUNT,


### PR DESCRIPTION
## Summary
- document the proof module layout, versioning policy, and compatibility guarantees
- move shared envelope serialization helpers into a new `proof::ser` module and update callers
- refresh the proof module re-exports to surface canonical types and the verifier entry point

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e3646cbd788326b7f1981aa3641c9b