### PR TITLE
Update proof docs and exports for new proof types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,9 @@ pub mod vrf;
 use config::{ProofSystemConfig, ProverContext, VerifierContext};
 use proof::aggregation::{BatchProofRecord, BatchVerificationOutcome};
 use proof::public_inputs::PublicInputs;
-use proof::types::VerifyError;
 use proof::ProofKind;
+
+pub use proof::types::{Proof, Telemetry, VerifyError, VerifyReport, PROOF_VERSION};
 use utils::serialization::{ProofBytes, WitnessBlob};
 
 pub use air::example::{
@@ -74,8 +75,8 @@ pub enum VerificationVerdict {
 /// 2. Ingest the phase-2 public input layout using [`PublicInputs`].
 /// 3. Absorb the witness container and execute the pipeline described in
 ///    [`proof::prover::PipelineSpec`].
-/// 4. Assemble the envelope defined in [`proof::envelope::ProofEnvelopeSpec`]
-///    and emit the serialized bytes.
+/// 4. Assemble the [`proof::types::Proof`] container and serialise it using the
+///    canonical helpers exposed by [`proof::ser`].
 ///
 /// No implementation logic is provided here; integrators must supply the
 /// execution engine while preserving the documented order of operations.
@@ -123,7 +124,7 @@ pub fn batch_verify(
     Err(StarkError::NotImplemented("batch_verify contract only"))
 }
 
-/// Convenience helper returning the canonical proof envelope layout.
+/// Convenience helper describing the canonical proof envelope layout.
 pub fn proof_envelope_spec() -> &'static str {
-    "See proof::envelope for the canonical layout implementation."
+    "See proof::types::Proof and proof::ser for the canonical layout implementation."
 }

--- a/tests/spec.md
+++ b/tests/spec.md
@@ -6,12 +6,12 @@ expected to satisfy the following behavioural contracts once wired in:
 ## Deterministic Proving
 - `generate_proof` must be deterministic for a fixed combination of
   `ProofKind`, public inputs, witness blob and `ProverContext`.
-- VRF commitments embedded inside the `ProofEnvelope` must be derived solely
-  from prover-side state; no verifier challenge is allowed during the
+- VRF commitments embedded inside the `proof::types::Proof` payload must be
+  derived solely from prover-side state; no verifier challenge is allowed during the
   generation phase.
 
 ## Envelope and Size Checks
-- Every produced `ProofEnvelope` must respect `MAX_PROOF_SIZE_BYTES` including
+- Every produced `proof::types::Proof` must respect `MAX_PROOF_SIZE_BYTES` including
   metadata and body payload.
 - Header lengths must match the serialized payload lengths documented in
   `public_inputs.rs` and the integrity digest must bind both segments.


### PR DESCRIPTION
## Summary
- re-export the canonical proof data structures and verify error from the proof::types module
- refresh crate-level documentation to reference proof::types::Proof and the proof::ser helpers
- update determinism specification notes to use the new proof container terminology

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68e37509fac4832683bb85d8f97f90a5