### PR TITLE
Add verification stage telemetry and modernize error variants

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -809,6 +809,6 @@ mod tests {
             None,
         );
 
-        assert!(matches!(result, Err(VerifyError::ParamDigestMismatch)));
+        assert!(matches!(result, Err(VerifyError::ParamsHashMismatch)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub fn generate_proof(
 /// The verification logic MUST execute the steps described in
 /// [`proof::verifier::SingleVerifySpec`]. The `config` and `verifier_context`
 /// parameters must match the ones used by the prover; otherwise
-/// [`proof::types::VerifyError::ParamDigestMismatch`] is expected.
+/// [`proof::types::VerifyError::ParamsHashMismatch`] is expected.
 pub fn verify_proof(
     kind: ProofKind,
     public_inputs: &PublicInputs<'_>,

--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -12,6 +12,8 @@ use crate::utils::serialization::ProofBytes;
 
 use super::public_inputs::PublicInputs;
 use super::types::VerifyError;
+#[cfg(test)]
+use super::types::MerkleSection;
 use super::verifier::{execute_fri_stage, precheck_proof_bytes, PrecheckedProof};
 
 /// Domain prefix used when deriving aggregation seeds.
@@ -427,7 +429,7 @@ mod tests {
             &verifier_context,
             |item, _, _, _| {
                 if item.original_index == 1 {
-                    Err(VerifyError::ParamDigestMismatch)
+                    Err(VerifyError::ParamsHashMismatch)
                 } else {
                     Ok(dummy_prechecked_proof())
                 }
@@ -439,7 +441,7 @@ mod tests {
             outcome,
             BatchVerificationOutcome::Reject {
                 failing_proof_index: 1,
-                error: VerifyError::ParamDigestMismatch,
+                error: VerifyError::ParamsHashMismatch,
             }
         );
     }
@@ -464,7 +466,9 @@ mod tests {
             |_, _, _, _| Ok(dummy_prechecked_proof()),
             |item, _| {
                 if item.original_index == 2 {
-                    Err(VerifyError::FriPathInvalid)
+                    Err(VerifyError::MerkleVerifyFailed {
+                        section: MerkleSection::FriPath,
+                    })
                 } else {
                     Ok(())
                 }
@@ -475,7 +479,9 @@ mod tests {
             outcome,
             BatchVerificationOutcome::Reject {
                 failing_proof_index: 2,
-                error: VerifyError::FriPathInvalid,
+                error: VerifyError::MerkleVerifyFailed {
+                    section: MerkleSection::FriPath,
+                },
             }
         );
     }

--- a/src/proof/ser.rs
+++ b/src/proof/ser.rs
@@ -272,7 +272,10 @@ pub fn deserialize_proof(bytes: &[u8]) -> Result<Proof, VerifyError> {
         .read_u16(SerKind::Proof, "version")
         .map_err(map_ser_error)?;
     if version != PROOF_VERSION {
-        return Err(VerifyError::UnsupportedVersion(version));
+        return Err(VerifyError::VersionMismatch {
+            expected: PROOF_VERSION,
+            actual: version,
+        });
     }
 
     let param_digest = ParamDigest(DigestBytes {

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -11,8 +11,8 @@ use rpp_stark::proof::envelope::{
 use rpp_stark::proof::public_inputs::{ExecutionHeaderV1, PublicInputVersion, PublicInputs};
 use rpp_stark::proof::transcript::{Transcript, TranscriptBlockContext, TranscriptHeader};
 use rpp_stark::proof::types::{
-    FriParametersMirror, MerkleProofBundle, Openings, OutOfDomainOpening, Proof, Telemetry,
-    VerifyError, PROOF_ALPHA_VECTOR_LEN, PROOF_MIN_OOD_POINTS, PROOF_VERSION,
+    FriParametersMirror, FriVerifyIssue, MerkleProofBundle, Openings, OutOfDomainOpening, Proof,
+    Telemetry, VerifyError, PROOF_ALPHA_VECTOR_LEN, PROOF_MIN_OOD_POINTS, PROOF_VERSION,
 };
 use rpp_stark::proof::verifier::verify_proof_bytes;
 use rpp_stark::utils::serialization::{DigestBytes, ProofBytes};
@@ -59,7 +59,12 @@ fn fri_layer_overflow_is_rejected() {
     )
     .expect("verify report");
 
-    assert_eq!(report.error, Some(VerifyError::FriLayerRootMismatch));
+    assert_eq!(
+        report.error,
+        Some(VerifyError::FriVerifyFailed {
+            issue: FriVerifyIssue::LayerBudgetExceeded,
+        })
+    );
 }
 
 #[test]
@@ -80,7 +85,12 @@ fn fri_query_budget_limit_is_enforced() {
     )
     .expect("verify report");
 
-    assert_eq!(report.error, Some(VerifyError::FriQueryOutOfRange));
+    assert_eq!(
+        report.error,
+        Some(VerifyError::FriVerifyFailed {
+            issue: FriVerifyIssue::QueryOutOfRange,
+        })
+    );
 }
 
 #[test]

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -5,11 +5,11 @@
 //! 1. Determinism: identical inputs (kind, public inputs, witness, config,
 //!    contexts) must produce bit-identical `proof_bytes`.
 //! 2. Parameter digest mismatch: modifying any byte in `ParamDigest` must
-//!    surface the `ErrParamDigestMismatch` failure.
+//!    surface the `ErrParamsHashMismatch` failure.
 //! 3. Merkle sibling order: swapping siblings in a FRI path must return
-//!    the `ErrFRIPathInvalid` failure.
+//!    the `ErrMerkleVerifyFailed(FriPath)` failure.
 //! 4. Query position bounds: queries outside the evaluation domain must be
-//!    flagged as `ErrFRIQueryOutOfRange`.
+//!    flagged as `ErrFriVerifyFailed(QueryOutOfRange)`.
 //! 5. Proof size guard: exceeding `limits.max_proof_size_bytes` must trigger
 //!    the `ErrProofTooLarge` failure.
 //! 6. Batch rejection: any failing proof in a batch must reject the batch,


### PR DESCRIPTION
## Summary
- extend `VerifyReport` with stage booleans and byte length telemetry while keeping serde compatibility
- reorganize `VerifyError` into new Merkle/FRI variants and rename the parameter digest mismatch to `ParamsHashMismatch`
- update verifier, prover, aggregation tests, and limit specs to track the new fields and variants

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e3a8a60da483269b9cbced95950857