### PR TITLE
Refactor verifier to accept decoded proofs

### DIFF
--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -11,9 +11,9 @@ use crate::proof::transcript::TranscriptBlockContext;
 use crate::utils::serialization::ProofBytes;
 
 use super::public_inputs::PublicInputs;
-use super::types::VerifyError;
 #[cfg(test)]
 use super::types::MerkleSection;
+use super::types::VerifyError;
 use super::verifier::{execute_fri_stage, precheck_proof_bytes, PrecheckedProof};
 
 /// Domain prefix used when deriving aggregation seeds.

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -38,4 +38,4 @@ pub mod transcript;
 
 pub use public_inputs::ProofKind;
 pub use types::{Openings, Proof, Telemetry, VerifyError, VerifyReport};
-pub use verifier::verify_proof_bytes as verify;
+pub use verifier::verify;


### PR DESCRIPTION
## Summary
- add `VerifierBindings` helpers that derive verification contexts from `StarkParams` and update `verify` to consume decoded proofs directly
- update proof exports to use the new verifier entry point
- adjust limit tests to construct `Proof` values and exercise the verifier via `StarkParams`

## Testing
- cargo test limits -- --nocapture


------
https://chatgpt.com/codex/tasks/task_e_68e3d562dc388326a2e77eaf5c15b39e