### PR TITLE
Refactor proof skeleton types and APIs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use proof::public_inputs::PublicInputs;
 use proof::ProofKind;
 
 pub use proof::types::{Proof, Telemetry, VerifyError, VerifyReport, PROOF_VERSION};
+pub use proof::verify;
 use utils::serialization::{ProofBytes, WitnessBlob};
 
 pub use air::example::{

--- a/src/proof/aggregation.rs
+++ b/src/proof/aggregation.rs
@@ -11,9 +11,9 @@ use crate::proof::transcript::TranscriptBlockContext;
 use crate::utils::serialization::ProofBytes;
 
 use super::public_inputs::PublicInputs;
-use super::types::VerifyError;
 #[cfg(test)]
 use super::types::MerkleSection;
+use super::types::VerifyError;
 use super::verifier::{execute_fri_stage, precheck_proof_bytes, PrecheckedProof};
 
 /// Domain prefix used when deriving aggregation seeds.
@@ -260,7 +260,7 @@ mod tests {
         AggregationHeaderV1, ExecutionHeaderV1, PublicInputVersion, PublicInputs, RecursionHeaderV1,
     };
     use crate::proof::types::{
-        FriParametersMirror, MerkleProofBundle, Openings, Proof, Telemetry, PROOF_VERSION,
+        FriTelemetry, MerkleProofBundle, Openings, Proof, Telemetry, PROOF_VERSION,
     };
     use crate::proof::verifier::PrecheckedProof;
     use crate::utils::serialization::{DigestBytes, FieldElementBytes, ProofBytes};
@@ -349,20 +349,18 @@ mod tests {
     fn dummy_prechecked_proof() -> PrecheckedProof {
         PrecheckedProof {
             proof: Proof {
-                version: PROOF_VERSION,
-                kind: crate::config::ProofKind::Tx,
-                param_digest: ParamDigest(DigestBytes { bytes: [7u8; 32] }),
+                proof_version: PROOF_VERSION,
+                proof_kind: crate::config::ProofKind::Tx,
+                params_hash: ParamDigest(DigestBytes { bytes: [7u8; 32] }).0.bytes,
                 air_spec_id: crate::config::AIR_SPEC_IDS_V1.tx.clone(),
                 public_inputs: Vec::new(),
                 commitment_digest: DigestBytes { bytes: [8u8; 32] },
                 merkle: MerkleProofBundle {
-                    core_root: [0u8; 32],
-                    aux_root: [0u8; 32],
-                    fri_layer_roots: Vec::new(),
+                    trace_cap: [0u8; 32],
+                    composition_cap: [0u8; 32],
+                    fri_layers: Vec::new(),
                 },
-                openings: Openings {
-                    out_of_domain: Vec::new(),
-                },
+                openings: Openings { trace: Vec::new() },
                 fri_proof: crate::fri::FriProof::new(
                     crate::fri::FriSecurityLevel::Standard,
                     1,
@@ -374,10 +372,10 @@ mod tests {
                 )
                 .expect("empty fri proof"),
                 telemetry: Telemetry {
-                    header_length: 0,
-                    body_length: 0,
-                    fri_parameters: FriParametersMirror::default(),
-                    integrity_digest: DigestBytes { bytes: [9u8; 32] },
+                    header_bytes: 0,
+                    body_bytes: 0,
+                    fri: crate::proof::types::FriTelemetry::default(),
+                    integrity_hash: DigestBytes { bytes: [9u8; 32] },
                 },
             },
             fri_seed: [10u8; 32],

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -3,27 +3,14 @@
 //! ```text
 //! proof
 //! ├── types      — canonical data models such as [`types::Proof`]
-//! ├── ser        — serialization helpers binding the stable byte layout
-//! ├── envelope   — deterministic encoding/decoding for [`types::Proof`]
-//! └── verifier   — verification contracts mirroring the specification
+//! ├── ser        — serialization helpers exposing public function signatures
+//! ├── envelope   — envelope builder scaffolding around [`types::Proof`]
+//! └── verifier   — verification contracts exporting [`verifier::verify`]
 //! ```
 //!
-//! ## Versioning policy
-//!
-//! The [`types::Proof`] container records the canonical proof version and
-//! layout declared by the specification. Minor revisions may extend telemetry or
-//! auxiliary metadata, but the header ordering and byte tags remain stable for
-//! a full major release. Any incompatible change to [`types::Proof`] must bump
-//! the crate's major version and update the documented constants exported by the
-//! `types` module.
-//!
-//! ## Compatibility guarantees
-//!
-//! Proof builders and verifiers are expected to treat the structure described by
-//! [`types::Proof`] as authoritative. New fields are appended in a
-//! backward-compatible manner and always guarded by explicit length prefixes.
-//! Consumers can therefore safely decode envelopes emitted by older minor
-//! releases while rejecting payloads that advertise an unsupported `version`.
+//! The module currently provides type definitions and API shells that mirror the
+//! specification. Implementations intentionally use `todo!()` so downstream
+//! consumers can plug in real logic without altering the public surface.
 
 pub mod envelope;
 pub mod ser;
@@ -37,5 +24,8 @@ pub mod public_inputs;
 pub mod transcript;
 
 pub use public_inputs::ProofKind;
-pub use types::{Openings, Proof, Telemetry, VerifyError, VerifyReport};
-pub use verifier::verify_proof_bytes as verify;
+pub use types::{
+    FriTelemetry, MerkleProofBundle, Openings, Proof, Telemetry, VerifyError, VerifyReport,
+    PROOF_VERSION,
+};
+pub use verifier::verify;

--- a/src/proof/ser.rs
+++ b/src/proof/ser.rs
@@ -1,830 +1,116 @@
 //! Serialization helpers for the proof envelope.
 //!
-//! The routines in this module encapsulate the canonical byte-level contracts
-//! shared by the prover and verifier. They intentionally expose pure helpers so
-//! the layout documented by [`super::types::Proof`] can be reused across the
-//! crate without reimplementing framing logic.
+//! This module currently exposes the public function signatures required by the
+//! documentation crate. Implementations are intentionally left as `todo!()` so
+//! integrators can fill in the actual byte-level layout when wiring the proving
+//! pipeline.
 
-use crate::config::{AirSpecId, ParamDigest, ProofKind};
-use crate::fri::FriProof;
-use crate::hash::Hasher;
-use crate::proof::public_inputs::{
-    AggregationHeaderV1, ExecutionHeaderV1, ProofKind as PublicProofKind, PublicInputVersion,
-    PublicInputs, RecursionHeaderV1, VrfHeaderV1,
-};
-use crate::proof::types::{
-    FriParametersMirror, MerkleProofBundle, Openings, OutOfDomainOpening, Proof, SerKind,
-    Telemetry, VerifyError, PROOF_VERSION,
-};
-use crate::utils::serialization::DigestBytes;
-
-const DIGEST_SIZE: usize = 32;
+use crate::config::ProofKind;
+use crate::proof::public_inputs::{ProofKind as PublicProofKind, PublicInputs};
+use crate::proof::types::{Openings, OutOfDomainOpening, Proof, Telemetry, VerifyError};
 
 /// Serialization failure surfaced while encoding a structure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SerError {
     /// Input ended before the expected number of bytes were read.
-    UnexpectedEnd { kind: SerKind, field: &'static str },
+    UnexpectedEnd {
+        kind: super::types::SerKind,
+        field: &'static str,
+    },
     /// A length prefix exceeded the configured bounds or remaining buffer.
-    InvalidLength { kind: SerKind, field: &'static str },
+    InvalidLength {
+        kind: super::types::SerKind,
+        field: &'static str,
+    },
     /// Encountered an unexpected discriminant or mismatching digest.
-    InvalidValue { kind: SerKind, field: &'static str },
+    InvalidValue {
+        kind: super::types::SerKind,
+        field: &'static str,
+    },
 }
 
 impl SerError {
-    fn unexpected_end(kind: SerKind, field: &'static str) -> Self {
+    /// Helper for signalling unexpected end-of-buffer conditions.
+    pub fn unexpected_end(kind: super::types::SerKind, field: &'static str) -> Self {
         SerError::UnexpectedEnd { kind, field }
     }
 
-    fn invalid_length(kind: SerKind, field: &'static str) -> Self {
+    /// Helper for signalling invalid length prefixes.
+    pub fn invalid_length(kind: super::types::SerKind, field: &'static str) -> Self {
         SerError::InvalidLength { kind, field }
     }
 
-    fn invalid_value(kind: SerKind, field: &'static str) -> Self {
+    /// Helper for signalling invalid discriminants.
+    pub fn invalid_value(kind: super::types::SerKind, field: &'static str) -> Self {
         SerError::InvalidValue { kind, field }
     }
 }
 
-fn map_ser_error(err: SerError) -> VerifyError {
-    VerifyError::Serialization(match err {
-        SerError::UnexpectedEnd { kind, .. }
-        | SerError::InvalidLength { kind, .. }
-        | SerError::InvalidValue { kind, .. } => kind,
-    })
-}
-
-/// Computes the commitment digest over core, auxiliary and FRI layer roots.
+/// Computes the commitment digest over the commitment bundle.
 pub fn compute_commitment_digest(
-    core_root: &[u8; 32],
-    aux_root: &[u8; 32],
-    fri_layer_roots: &[[u8; 32]],
+    _trace_cap: &[u8; 32],
+    _composition_cap: &[u8; 32],
+    _fri_layers: &[[u8; 32]],
 ) -> [u8; 32] {
-    let mut hasher = Hasher::new();
-    hasher.update(core_root);
-    hasher.update(aux_root);
-    for root in fri_layer_roots {
-        hasher.update(root);
-    }
-    *hasher.finalize().as_bytes()
+    todo!("compute_commitment_digest is not implemented yet")
 }
 
 /// Computes the integrity digest over the header bytes and body payload.
-pub fn compute_integrity_digest(header_bytes: &[u8], body_payload: &[u8]) -> [u8; 32] {
-    let mut hasher = Hasher::new();
-    hasher.update(header_bytes);
-    hasher.update(body_payload);
-    *hasher.finalize().as_bytes()
+pub fn compute_integrity_digest(_header_bytes: &[u8], _body_payload: &[u8]) -> [u8; 32] {
+    todo!("compute_integrity_digest is not implemented yet")
 }
 
 /// Serialises the public inputs using the canonical layout.
-pub fn serialize_public_inputs(inputs: &PublicInputs<'_>) -> Vec<u8> {
-    fn version_byte(version: PublicInputVersion) -> u8 {
-        match version {
-            PublicInputVersion::V1 => 1,
-        }
-    }
-
-    match inputs {
-        PublicInputs::Execution { header, body } => {
-            let ExecutionHeaderV1 {
-                version,
-                program_digest,
-                trace_length,
-                trace_width,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.extend_from_slice(&program_digest.bytes);
-            buffer.extend_from_slice(&trace_length.to_le_bytes());
-            buffer.extend_from_slice(&trace_width.to_le_bytes());
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-        PublicInputs::Aggregation { header, body } => {
-            let AggregationHeaderV1 {
-                version,
-                circuit_digest,
-                leaf_count,
-                root_digest,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.extend_from_slice(&circuit_digest.bytes);
-            buffer.extend_from_slice(&leaf_count.to_le_bytes());
-            buffer.extend_from_slice(&root_digest.bytes);
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-        PublicInputs::Recursion { header, body } => {
-            let RecursionHeaderV1 {
-                version,
-                depth,
-                boundary_digest,
-                recursion_seed,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.push(*depth);
-            buffer.extend_from_slice(&boundary_digest.bytes);
-            buffer.extend_from_slice(&recursion_seed.bytes);
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-        PublicInputs::Vrf { header, body } => {
-            let VrfHeaderV1 {
-                version,
-                public_key_commit,
-                prf_param_digest,
-                rlwe_param_id,
-                vrf_param_id,
-                transcript_version_id,
-                field_id,
-                context_digest,
-            } = header;
-            let mut buffer = Vec::new();
-            buffer.push(version_byte(*version));
-            buffer.extend_from_slice(&public_key_commit.bytes);
-            buffer.extend_from_slice(&prf_param_digest.bytes);
-            buffer.extend_from_slice(rlwe_param_id.as_bytes());
-            buffer.extend_from_slice(vrf_param_id.as_bytes());
-            let tv = transcript_version_id.clone().bytes();
-            buffer.extend_from_slice(&tv.bytes);
-            buffer.extend_from_slice(&field_id.to_le_bytes());
-            buffer.extend_from_slice(&context_digest.bytes);
-            buffer.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(body);
-            buffer
-        }
-    }
+pub fn serialize_public_inputs(_inputs: &PublicInputs<'_>) -> Vec<u8> {
+    todo!("serialize_public_inputs is not implemented yet")
 }
 
-/// Maps a public-input proof kind to the global configuration ordering.
-pub fn map_public_to_config_kind(kind: PublicProofKind) -> ProofKind {
-    use crate::proof::public_inputs::ProofKind as PublicKind;
-    match kind {
-        PublicKind::Execution => ProofKind::Tx,
-        PublicKind::Aggregation => ProofKind::Aggregation,
-        PublicKind::Recursion => ProofKind::State,
-        PublicKind::VrfPostQuantum => ProofKind::VRF,
-    }
+/// Maps a public proof kind to the configuration proof kind enumeration.
+pub fn map_public_to_config_kind(_kind: PublicProofKind) -> ProofKind {
+    todo!("map_public_to_config_kind is not implemented yet")
 }
 
-pub(crate) fn encode_proof_kind(kind: ProofKind) -> u8 {
-    match kind {
-        ProofKind::Tx => 0,
-        ProofKind::State => 1,
-        ProofKind::Pruning => 2,
-        ProofKind::Uptime => 3,
-        ProofKind::Consensus => 4,
-        ProofKind::Identity => 5,
-        ProofKind::Aggregation => 6,
-        ProofKind::VRF => 7,
-    }
+/// Serialises a [`Proof`] into its canonical byte representation.
+pub fn serialize_proof(_proof: &Proof) -> Result<Vec<u8>, SerError> {
+    todo!("serialize_proof is not implemented yet")
 }
 
-pub(crate) fn decode_proof_kind(byte: u8) -> Result<ProofKind, VerifyError> {
-    Ok(match byte {
-        0 => ProofKind::Tx,
-        1 => ProofKind::State,
-        2 => ProofKind::Pruning,
-        3 => ProofKind::Uptime,
-        4 => ProofKind::Consensus,
-        5 => ProofKind::Identity,
-        6 => ProofKind::Aggregation,
-        7 => ProofKind::VRF,
-        other => return Err(VerifyError::UnknownProofKind(other)),
-    })
+/// Deserialises a proof from its canonical representation.
+pub fn deserialize_proof(_bytes: &[u8]) -> Result<Proof, VerifyError> {
+    todo!("deserialize_proof is not implemented yet")
 }
 
-fn decode_proof_kind_ser(byte: u8) -> Result<ProofKind, SerError> {
-    decode_proof_kind(byte).map_err(|_| SerError::invalid_value(SerKind::Telemetry, "proof_kind"))
+/// Serialises an [`Openings`] payload.
+pub fn serialize_openings(_openings: &Openings) -> Vec<u8> {
+    todo!("serialize_openings is not implemented yet")
 }
 
-pub(crate) fn serialize_fri_proof(proof: &FriProof) -> Vec<u8> {
-    proof
-        .to_bytes()
-        .expect("FRI proofs embedded in envelopes must be valid")
+/// Serialises a single out-of-domain opening entry.
+pub fn serialize_out_of_domain_opening(_opening: &OutOfDomainOpening) -> Vec<u8> {
+    todo!("serialize_out_of_domain_opening is not implemented yet")
 }
 
-pub(crate) fn deserialize_fri_proof(bytes: &[u8]) -> Result<FriProof, VerifyError> {
-    FriProof::from_bytes(bytes).map_err(|_| VerifyError::Serialization(SerKind::Fri))
+/// Deserialises a single out-of-domain opening entry.
+pub fn deserialize_out_of_domain_opening(_bytes: &[u8]) -> Result<OutOfDomainOpening, VerifyError> {
+    todo!("deserialize_out_of_domain_opening is not implemented yet")
 }
 
-fn compute_public_digest(bytes: &[u8]) -> [u8; DIGEST_SIZE] {
-    let mut hasher = Hasher::new();
-    hasher.update(bytes);
-    *hasher.finalize().as_bytes()
+/// Serialises the proof header given the already encoded payload bytes.
+pub fn serialize_proof_header(_proof: &Proof, _payload: &[u8]) -> Vec<u8> {
+    todo!("serialize_proof_header is not implemented yet")
 }
 
-fn ensure_u32(value: usize, kind: SerKind, field: &'static str) -> Result<u32, SerError> {
-    u32::try_from(value).map_err(|_| SerError::invalid_length(kind, field))
+/// Serialises the proof payload body.
+pub fn serialize_proof_payload(_proof: &Proof) -> Vec<u8> {
+    todo!("serialize_proof_payload is not implemented yet")
 }
 
-/// Serialises a [`Proof`] into the canonical envelope layout.
-pub fn serialize_proof(proof: &Proof) -> Result<Vec<u8>, SerError> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&proof.version.to_le_bytes());
-    out.extend_from_slice(&proof.param_digest.0.bytes);
-
-    let public_digest = compute_public_digest(&proof.public_inputs);
-    out.extend_from_slice(&public_digest);
-
-    let merkle_bytes = serialize_merkle_bundle(&proof.merkle)?;
-    out.extend_from_slice(
-        &ensure_u32(merkle_bytes.len(), SerKind::TraceCommitment, "len")?.to_le_bytes(),
-    );
-    out.extend_from_slice(&merkle_bytes);
-
-    let has_composition = proof.commitment_digest.bytes != [0u8; DIGEST_SIZE];
-    out.push(if has_composition { 1 } else { 0 });
-    if has_composition {
-        out.extend_from_slice(&proof.commitment_digest.bytes);
-    }
-
-    let fri_bytes = serialize_fri_proof(&proof.fri_proof);
-    out.extend_from_slice(&ensure_u32(fri_bytes.len(), SerKind::Fri, "len")?.to_le_bytes());
-    out.extend_from_slice(&fri_bytes);
-
-    let openings_bytes = encode_openings(&proof.openings)?;
-    out.extend_from_slice(
-        &ensure_u32(openings_bytes.len(), SerKind::Openings, "len")?.to_le_bytes(),
-    );
-    out.extend_from_slice(&openings_bytes);
-
-    out.push(1); // telemetry always present in the documentation layer.
-    let telemetry_bytes = serialize_telemetry_frame(proof)?;
-    out.extend_from_slice(
-        &ensure_u32(telemetry_bytes.len(), SerKind::Telemetry, "len")?.to_le_bytes(),
-    );
-    out.extend_from_slice(&telemetry_bytes);
-
-    Ok(out)
+/// Serialises the telemetry frame into bytes.
+pub fn serialize_telemetry(_telemetry: &Telemetry) -> Vec<u8> {
+    todo!("serialize_telemetry is not implemented yet")
 }
 
-/// Deserialises a [`Proof`] from its canonical byte layout.
-pub fn deserialize_proof(bytes: &[u8]) -> Result<Proof, VerifyError> {
-    let mut cursor = Cursor::new(bytes);
-
-    let version = cursor
-        .read_u16(SerKind::Proof, "version")
-        .map_err(map_ser_error)?;
-    if version != PROOF_VERSION {
-        return Err(VerifyError::VersionMismatch {
-            expected: PROOF_VERSION,
-            actual: version,
-        });
-    }
-
-    let param_digest = ParamDigest(DigestBytes {
-        bytes: cursor
-            .read_digest(SerKind::Proof, "param_digest")
-            .map_err(map_ser_error)?,
-    });
-
-    let public_digest = cursor
-        .read_digest(SerKind::PublicInputs, "public_digest")
-        .map_err(map_ser_error)?;
-
-    let merkle_len = cursor
-        .read_u32(SerKind::TraceCommitment, "len")
-        .map_err(map_ser_error)? as usize;
-    let merkle_bytes = cursor
-        .read_vec(SerKind::TraceCommitment, "bytes", merkle_len)
-        .map_err(map_ser_error)?;
-    let merkle = deserialize_merkle_bundle(&merkle_bytes).map_err(map_ser_error)?;
-
-    let has_comp = cursor
-        .read_u8(SerKind::CompositionCommitment, "flag")
-        .map_err(map_ser_error)?;
-    let commitment_digest = match has_comp {
-        0 => DigestBytes::default(),
-        1 => DigestBytes {
-            bytes: cursor
-                .read_digest(SerKind::CompositionCommitment, "digest")
-                .map_err(map_ser_error)?,
-        },
-        _ => return Err(VerifyError::Serialization(SerKind::CompositionCommitment)),
-    };
-
-    let fri_len = cursor
-        .read_u32(SerKind::Fri, "len")
-        .map_err(map_ser_error)? as usize;
-    let fri_bytes = cursor
-        .read_vec(SerKind::Fri, "bytes", fri_len)
-        .map_err(map_ser_error)?;
-    let fri_proof =
-        deserialize_fri_proof(&fri_bytes).map_err(|_| VerifyError::Serialization(SerKind::Fri))?;
-
-    let openings_len = cursor
-        .read_u32(SerKind::Openings, "len")
-        .map_err(map_ser_error)? as usize;
-    let openings_bytes = cursor
-        .read_vec(SerKind::Openings, "bytes", openings_len)
-        .map_err(map_ser_error)?;
-    let openings = deserialize_openings(&openings_bytes).map_err(map_ser_error)?;
-
-    let has_telemetry = cursor
-        .read_u8(SerKind::Telemetry, "flag")
-        .map_err(map_ser_error)?;
-    let telemetry_data = if has_telemetry == 1 {
-        let telemetry_len = cursor
-            .read_u32(SerKind::Telemetry, "len")
-            .map_err(map_ser_error)? as usize;
-        let telemetry_bytes = cursor
-            .read_vec(SerKind::Telemetry, "bytes", telemetry_len)
-            .map_err(map_ser_error)?;
-        deserialize_telemetry_frame(&telemetry_bytes, public_digest).map_err(map_ser_error)?
-    } else {
-        return Err(VerifyError::Serialization(SerKind::Telemetry));
-    };
-
-    if cursor.remaining() != 0 {
-        return Err(VerifyError::Serialization(SerKind::Proof));
-    }
-
-    Ok(Proof {
-        version,
-        kind: telemetry_data.kind,
-        param_digest,
-        air_spec_id: telemetry_data.air_spec_id,
-        public_inputs: telemetry_data.public_inputs,
-        commitment_digest,
-        merkle,
-        openings,
-        fri_proof,
-        telemetry: telemetry_data.telemetry,
-    })
-}
-
-struct TelemetryDecodeResult {
-    telemetry: Telemetry,
-    kind: ProofKind,
-    air_spec_id: AirSpecId,
-    public_inputs: Vec<u8>,
-}
-
-fn serialize_merkle_bundle(bundle: &MerkleProofBundle) -> Result<Vec<u8>, SerError> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&bundle.core_root);
-    out.extend_from_slice(&bundle.aux_root);
-    out.extend_from_slice(
-        &ensure_u32(
-            bundle.fri_layer_roots.len(),
-            SerKind::TraceCommitment,
-            "fri_roots",
-        )?
-        .to_le_bytes(),
-    );
-    for root in &bundle.fri_layer_roots {
-        out.extend_from_slice(root);
-    }
-    Ok(out)
-}
-
-fn deserialize_merkle_bundle(bytes: &[u8]) -> Result<MerkleProofBundle, SerError> {
-    let mut cursor = Cursor::new(bytes);
-    let core_root = cursor.read_digest(SerKind::TraceCommitment, "core_root")?;
-    let aux_root = cursor.read_digest(SerKind::TraceCommitment, "aux_root")?;
-    let layer_count = cursor.read_u32(SerKind::TraceCommitment, "fri_roots")? as usize;
-    let mut fri_layer_roots = Vec::with_capacity(layer_count);
-    for _ in 0..layer_count {
-        fri_layer_roots.push(cursor.read_digest(SerKind::TraceCommitment, "fri_root")?);
-    }
-    if cursor.remaining() != 0 {
-        return Err(SerError::invalid_length(
-            SerKind::TraceCommitment,
-            "trailing_bytes",
-        ));
-    }
-    Ok(MerkleProofBundle {
-        core_root,
-        aux_root,
-        fri_layer_roots,
-    })
-}
-
-fn encode_openings(openings: &Openings) -> Result<Vec<u8>, SerError> {
-    let mut buffer = Vec::new();
-    buffer.extend_from_slice(
-        &ensure_u32(openings.out_of_domain.len(), SerKind::Openings, "ood_len")?.to_le_bytes(),
-    );
-    for opening in &openings.out_of_domain {
-        let encoded = serialize_out_of_domain_opening(opening);
-        buffer.extend_from_slice(
-            &ensure_u32(encoded.len(), SerKind::Openings, "ood_block")?.to_le_bytes(),
-        );
-        buffer.extend_from_slice(&encoded);
-    }
-    Ok(buffer)
-}
-
-fn deserialize_openings(bytes: &[u8]) -> Result<Openings, SerError> {
-    let mut cursor = Cursor::new(bytes);
-    let count = cursor.read_u32(SerKind::Openings, "ood_len")? as usize;
-    let mut out = Vec::with_capacity(count);
-    for _ in 0..count {
-        let block_len = cursor.read_u32(SerKind::Openings, "ood_block")? as usize;
-        let block = cursor.read_vec(SerKind::Openings, "ood_bytes", block_len)?;
-        let opening = deserialize_out_of_domain_opening_inner(&block)?;
-        out.push(opening);
-    }
-    if cursor.remaining() != 0 {
-        return Err(SerError::invalid_length(
-            SerKind::Openings,
-            "trailing_bytes",
-        ));
-    }
-    Ok(Openings { out_of_domain: out })
-}
-
-fn serialize_telemetry_frame(proof: &Proof) -> Result<Vec<u8>, SerError> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&proof.telemetry.header_length.to_le_bytes());
-    out.extend_from_slice(&proof.telemetry.body_length.to_le_bytes());
-    out.push(proof.telemetry.fri_parameters.fold);
-    out.extend_from_slice(&proof.telemetry.fri_parameters.cap_degree.to_le_bytes());
-    out.extend_from_slice(&proof.telemetry.fri_parameters.cap_size.to_le_bytes());
-    out.extend_from_slice(&proof.telemetry.fri_parameters.query_budget.to_le_bytes());
-    out.extend_from_slice(&proof.telemetry.integrity_digest.bytes);
-    out.push(encode_proof_kind(proof.kind));
-    let air_spec_bytes = proof.air_spec_id.clone().bytes();
-    out.extend_from_slice(&air_spec_bytes.bytes);
-    out.extend_from_slice(
-        &ensure_u32(proof.public_inputs.len(), SerKind::PublicInputs, "len")?.to_le_bytes(),
-    );
-    out.extend_from_slice(&proof.public_inputs);
-    Ok(out)
-}
-
-fn deserialize_telemetry_frame(
-    bytes: &[u8],
-    public_digest: [u8; DIGEST_SIZE],
-) -> Result<TelemetryDecodeResult, SerError> {
-    let mut cursor = Cursor::new(bytes);
-    let header_length = cursor.read_u32(SerKind::Telemetry, "header_length")?;
-    let body_length = cursor.read_u32(SerKind::Telemetry, "body_length")?;
-    let fold = cursor.read_u8(SerKind::Telemetry, "fri.fold")?;
-    let cap_degree = cursor.read_u16(SerKind::Telemetry, "fri.cap_degree")?;
-    let cap_size = cursor.read_u32(SerKind::Telemetry, "fri.cap_size")?;
-    let query_budget = cursor.read_u16(SerKind::Telemetry, "fri.query_budget")?;
-    let integrity_digest = cursor.read_digest(SerKind::Telemetry, "integrity_digest")?;
-    let kind_byte = cursor.read_u8(SerKind::Telemetry, "proof_kind")?;
-    let kind = decode_proof_kind_ser(kind_byte)?;
-    let air_spec_id = AirSpecId(DigestBytes {
-        bytes: cursor.read_digest(SerKind::Telemetry, "air_spec_id")?,
-    });
-    let public_len = cursor.read_u32(SerKind::PublicInputs, "len")? as usize;
-    let public_inputs = cursor.read_vec(SerKind::PublicInputs, "bytes", public_len)?;
-    if cursor.remaining() != 0 {
-        return Err(SerError::invalid_length(
-            SerKind::Telemetry,
-            "trailing_bytes",
-        ));
-    }
-    if compute_public_digest(&public_inputs) != public_digest {
-        return Err(SerError::invalid_value(
-            SerKind::PublicInputs,
-            "digest_mismatch",
-        ));
-    }
-
-    Ok(TelemetryDecodeResult {
-        telemetry: Telemetry {
-            header_length,
-            body_length,
-            fri_parameters: FriParametersMirror {
-                fold,
-                cap_degree,
-                cap_size,
-                query_budget,
-            },
-            integrity_digest: DigestBytes {
-                bytes: integrity_digest,
-            },
-        },
-        kind,
-        air_spec_id,
-        public_inputs,
-    })
-}
-
-/// Serialises the out-of-domain opening container.
-pub fn serialize_openings(openings: &Openings) -> Vec<u8> {
-    encode_openings(openings).expect("openings serialization should fit u32 lengths")
-}
-
-/// Serialises a single out-of-domain opening block.
-pub fn serialize_out_of_domain_opening(opening: &OutOfDomainOpening) -> Vec<u8> {
-    let mut buffer = Vec::new();
-    buffer.extend_from_slice(&opening.point);
-    buffer.extend_from_slice(&(opening.core_values.len() as u32).to_le_bytes());
-    for value in &opening.core_values {
-        buffer.extend_from_slice(value);
-    }
-    buffer.extend_from_slice(&(opening.aux_values.len() as u32).to_le_bytes());
-    for value in &opening.aux_values {
-        buffer.extend_from_slice(value);
-    }
-    buffer.extend_from_slice(&opening.composition_value);
-    buffer
-}
-
-fn deserialize_out_of_domain_opening_inner(bytes: &[u8]) -> Result<OutOfDomainOpening, SerError> {
-    let mut cursor = Cursor::new(bytes);
-    let point = cursor.read_digest(SerKind::Openings, "point")?;
-    let core_len = cursor.read_u32(SerKind::Openings, "core_len")? as usize;
-    let mut core_values = Vec::with_capacity(core_len);
-    for _ in 0..core_len {
-        core_values.push(cursor.read_digest(SerKind::Openings, "core_value")?);
-    }
-    let aux_len = cursor.read_u32(SerKind::Openings, "aux_len")? as usize;
-    let mut aux_values = Vec::with_capacity(aux_len);
-    for _ in 0..aux_len {
-        aux_values.push(cursor.read_digest(SerKind::Openings, "aux_value")?);
-    }
-    let composition_value = cursor.read_digest(SerKind::Openings, "composition_value")?;
-    if cursor.remaining() != 0 {
-        return Err(SerError::invalid_length(
-            SerKind::Openings,
-            "trailing_bytes",
-        ));
-    }
-    Ok(OutOfDomainOpening {
-        point,
-        core_values,
-        aux_values,
-        composition_value,
-    })
-}
-
-/// Deserialises an out-of-domain opening block.
-pub fn deserialize_out_of_domain_opening(bytes: &[u8]) -> Result<OutOfDomainOpening, VerifyError> {
-    deserialize_out_of_domain_opening_inner(bytes).map_err(map_ser_error)
-}
-
-/// Serialises the proof header given the payload bytes.
-pub fn serialize_proof_header(proof: &Proof, payload: &[u8]) -> Vec<u8> {
-    let body_length = (payload.len() + DIGEST_SIZE) as u32;
-    let header_length = (3 + 32 + 32 + 4 + proof.public_inputs.len() + 32 + 4 + 4) as u32;
-
-    let mut buffer = Vec::with_capacity(header_length as usize);
-    buffer.extend_from_slice(&proof.version.to_le_bytes());
-    buffer.push(encode_proof_kind(proof.kind));
-    buffer.extend_from_slice(&proof.param_digest.0.bytes);
-    let air_spec = proof.air_spec_id.clone().bytes();
-    buffer.extend_from_slice(&air_spec.bytes);
-    buffer.extend_from_slice(&(proof.public_inputs.len() as u32).to_le_bytes());
-    buffer.extend_from_slice(&proof.public_inputs);
-    buffer.extend_from_slice(&proof.commitment_digest.bytes);
-    buffer.extend_from_slice(&header_length.to_le_bytes());
-    buffer.extend_from_slice(&body_length.to_le_bytes());
-    buffer
-}
-
-/// Serialises the proof payload (body) without the integrity digest.
-pub fn serialize_proof_payload(proof: &Proof) -> Vec<u8> {
-    let mut buffer = Vec::new();
-    buffer.extend_from_slice(&proof.merkle.core_root);
-    buffer.extend_from_slice(&proof.merkle.aux_root);
-    buffer.extend_from_slice(&(proof.merkle.fri_layer_roots.len() as u32).to_le_bytes());
-    for root in &proof.merkle.fri_layer_roots {
-        buffer.extend_from_slice(root);
-    }
-
-    buffer.extend_from_slice(&(proof.openings.out_of_domain.len() as u32).to_le_bytes());
-    for opening in &proof.openings.out_of_domain {
-        let encoded = serialize_out_of_domain_opening(opening);
-        buffer.extend_from_slice(&(encoded.len() as u32).to_le_bytes());
-        buffer.extend_from_slice(&encoded);
-    }
-
-    let fri_bytes = serialize_fri_proof(&proof.fri_proof);
-    buffer.extend_from_slice(&(fri_bytes.len() as u32).to_le_bytes());
-    buffer.extend_from_slice(&fri_bytes);
-
-    buffer.push(proof.telemetry.fri_parameters.fold);
-    buffer.extend_from_slice(&proof.telemetry.fri_parameters.cap_degree.to_le_bytes());
-    buffer.extend_from_slice(&proof.telemetry.fri_parameters.cap_size.to_le_bytes());
-    buffer.extend_from_slice(&proof.telemetry.fri_parameters.query_budget.to_le_bytes());
-    buffer
-}
-
-struct Cursor<'a> {
-    bytes: &'a [u8],
-    offset: usize,
-}
-
-impl<'a> Cursor<'a> {
-    fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes, offset: 0 }
-    }
-
-    fn remaining(&self) -> usize {
-        self.bytes.len().saturating_sub(self.offset)
-    }
-
-    fn read_u8(&mut self, kind: SerKind, field: &'static str) -> Result<u8, SerError> {
-        if self.remaining() < 1 {
-            return Err(SerError::unexpected_end(kind, field));
-        }
-        let value = self.bytes[self.offset];
-        self.offset += 1;
-        Ok(value)
-    }
-
-    fn read_u16(&mut self, kind: SerKind, field: &'static str) -> Result<u16, SerError> {
-        if self.remaining() < 2 {
-            return Err(SerError::unexpected_end(kind, field));
-        }
-        let mut buf = [0u8; 2];
-        buf.copy_from_slice(&self.bytes[self.offset..self.offset + 2]);
-        self.offset += 2;
-        Ok(u16::from_le_bytes(buf))
-    }
-
-    fn read_u32(&mut self, kind: SerKind, field: &'static str) -> Result<u32, SerError> {
-        if self.remaining() < 4 {
-            return Err(SerError::unexpected_end(kind, field));
-        }
-        let mut buf = [0u8; 4];
-        buf.copy_from_slice(&self.bytes[self.offset..self.offset + 4]);
-        self.offset += 4;
-        Ok(u32::from_le_bytes(buf))
-    }
-
-    fn read_vec(
-        &mut self,
-        kind: SerKind,
-        field: &'static str,
-        len: usize,
-    ) -> Result<Vec<u8>, SerError> {
-        if self.remaining() < len {
-            return Err(SerError::unexpected_end(kind, field));
-        }
-        let slice = &self.bytes[self.offset..self.offset + len];
-        self.offset += len;
-        Ok(slice.to_vec())
-    }
-
-    fn read_digest(
-        &mut self,
-        kind: SerKind,
-        field: &'static str,
-    ) -> Result<[u8; DIGEST_SIZE], SerError> {
-        if self.remaining() < DIGEST_SIZE {
-            return Err(SerError::unexpected_end(kind, field));
-        }
-        let mut out = [0u8; DIGEST_SIZE];
-        out.copy_from_slice(&self.bytes[self.offset..self.offset + DIGEST_SIZE]);
-        self.offset += DIGEST_SIZE;
-        Ok(out)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::config::{ParamDigest as ConfigParamDigest, ProofKind};
-    use crate::field::FieldElement;
-    use crate::fri::{FriProof, FriSecurityLevel};
-    use crate::proof::public_inputs::{ExecutionHeaderV1, PublicInputVersion, PublicInputs};
-    use crate::utils::serialization::DigestBytes;
-
-    fn sample_fri_proof() -> FriProof {
-        let evaluations: Vec<FieldElement> = (0..64).map(|i| FieldElement(i as u64 + 1)).collect();
-        let seed = [7u8; 32];
-        FriProof::prove(FriSecurityLevel::Standard, seed, &evaluations).expect("fri proof")
-    }
-
-    fn build_sample_proof() -> Proof {
-        let fri_proof = sample_fri_proof();
-        let fri_layer_roots = fri_proof.layer_roots.clone();
-        let core_root = fri_layer_roots.first().copied().unwrap_or([0u8; 32]);
-        let aux_root = [1u8; 32];
-        let commitment_digest = compute_commitment_digest(&core_root, &aux_root, &fri_layer_roots);
-
-        let header = ExecutionHeaderV1 {
-            version: PublicInputVersion::V1,
-            program_digest: DigestBytes { bytes: [2u8; 32] },
-            trace_length: 64,
-            trace_width: 4,
-        };
-        let body_bytes: Vec<u8> = vec![1, 2, 3, 4];
-        let public_inputs = PublicInputs::Execution {
-            header: header.clone(),
-            body: &body_bytes,
-        };
-        let public_input_bytes = serialize_public_inputs(&public_inputs);
-
-        let merkle = MerkleProofBundle {
-            core_root,
-            aux_root,
-            fri_layer_roots,
-        };
-        let openings = Openings {
-            out_of_domain: vec![OutOfDomainOpening {
-                point: [3u8; 32],
-                core_values: vec![[4u8; 32]],
-                aux_values: Vec::new(),
-                composition_value: [5u8; 32],
-            }],
-        };
-        let mut proof = Proof {
-            version: PROOF_VERSION,
-            kind: ProofKind::Tx,
-            param_digest: ConfigParamDigest(DigestBytes { bytes: [6u8; 32] }),
-            air_spec_id: crate::config::AirSpecId(DigestBytes { bytes: [7u8; 32] }),
-            public_inputs: public_input_bytes,
-            commitment_digest: DigestBytes {
-                bytes: commitment_digest,
-            },
-            merkle,
-            openings,
-            fri_proof,
-            telemetry: Telemetry {
-                header_length: 0,
-                body_length: 0,
-                fri_parameters: FriParametersMirror {
-                    fold: 2,
-                    cap_degree: 0,
-                    cap_size: 0,
-                    query_budget: 0,
-                },
-                integrity_digest: DigestBytes::default(),
-            },
-        };
-
-        // Populate telemetry with deterministic values.
-        let payload = crate::proof::ser::serialize_proof_payload(&proof);
-        let header_bytes = crate::proof::ser::serialize_proof_header(&proof, &payload);
-        let integrity = compute_integrity_digest(&header_bytes, &payload);
-        proof.telemetry.header_length = header_bytes.len() as u32;
-        proof.telemetry.body_length = (payload.len() + 32) as u32;
-        proof.telemetry.integrity_digest = DigestBytes { bytes: integrity };
-
-        proof
-    }
-
-    #[test]
-    fn proof_round_trip() {
-        let proof = build_sample_proof();
-        let bytes = serialize_proof(&proof).expect("serialize proof");
-        let decoded = deserialize_proof(&bytes).expect("decode proof");
-        assert_eq!(proof, decoded);
-    }
-
-    #[test]
-    fn serialization_layout_matches_contract() {
-        let proof = build_sample_proof();
-        let bytes = serialize_proof(&proof).expect("serialize proof");
-        let mut cursor = Cursor::new(&bytes);
-        assert_eq!(
-            cursor.read_u16(SerKind::Proof, "version").unwrap(),
-            PROOF_VERSION
-        );
-        cursor.read_digest(SerKind::Proof, "param_digest").unwrap();
-        cursor
-            .read_digest(SerKind::PublicInputs, "public_digest")
-            .unwrap();
-        let merkle_len = cursor.read_u32(SerKind::TraceCommitment, "len").unwrap() as usize;
-        cursor
-            .read_vec(SerKind::TraceCommitment, "bytes", merkle_len)
-            .unwrap();
-        assert_eq!(
-            cursor
-                .read_u8(SerKind::CompositionCommitment, "flag")
-                .unwrap(),
-            1
-        );
-        cursor
-            .read_digest(SerKind::CompositionCommitment, "digest")
-            .unwrap();
-        let fri_len = cursor.read_u32(SerKind::Fri, "len").unwrap() as usize;
-        cursor.read_vec(SerKind::Fri, "bytes", fri_len).unwrap();
-        let openings_len = cursor.read_u32(SerKind::Openings, "len").unwrap() as usize;
-        cursor
-            .read_vec(SerKind::Openings, "bytes", openings_len)
-            .unwrap();
-        assert_eq!(cursor.read_u8(SerKind::Telemetry, "flag").unwrap(), 1);
-        let telemetry_len = cursor.read_u32(SerKind::Telemetry, "len").unwrap() as usize;
-        cursor
-            .read_vec(SerKind::Telemetry, "bytes", telemetry_len)
-            .unwrap();
-        assert_eq!(cursor.remaining(), 0);
-    }
-
-    #[test]
-    fn deserialize_rejects_truncated_payload() {
-        let proof = build_sample_proof();
-        let mut bytes = serialize_proof(&proof).expect("serialize proof");
-        bytes.pop();
-        let err = deserialize_proof(&bytes).expect_err("should fail");
-        match err {
-            VerifyError::Serialization(SerKind::Telemetry) => {}
-            other => panic!("unexpected error: {other:?}"),
-        }
-    }
+/// Deserialises the telemetry frame from bytes.
+pub fn deserialize_telemetry(_bytes: &[u8]) -> Result<Telemetry, VerifyError> {
+    todo!("deserialize_telemetry is not implemented yet")
 }

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -1,538 +1,86 @@
-//! Deterministic verifier implementation.
+//! Deterministic verifier skeleton.
 //!
-//! The verifier mirrors the prover pipeline by replaying the transcript,
-//! recomputing the Fiat–Shamir challenges and validating the FRI proof.  All
-//! structural checks (length prefixes, digests and bounds) are performed before
-//! any expensive cryptographic operation.
+//! The real verifier mirrors the prover pipeline by replaying the transcript,
+//! recomputing Fiat–Shamir challenges and validating the FRI proof.  This
+//! placeholder exposes the public API so downstream consumers can depend on the
+//! interfaces while the implementation is developed.
 
 use crate::config::{
-    ProofKind as ConfigProofKind, ProofKindLayout, ProofSystemConfig, VerifierContext,
+    AirSpecId, ProofKind as ConfigProofKind, ProofKindLayout, ProofSystemConfig, VerifierContext,
 };
-use crate::field::FieldElement;
 use crate::fri::types::{FriError, FriSecurityLevel};
-use crate::fri::FriVerifier;
-use crate::hash::Hasher;
 use crate::proof::public_inputs::PublicInputs;
-use crate::proof::ser::{
-    compute_commitment_digest, compute_integrity_digest, encode_proof_kind,
-    map_public_to_config_kind, serialize_public_inputs,
-};
-use crate::proof::transcript::{Transcript, TranscriptBlockContext, TranscriptHeader};
-use crate::proof::types::{
-    FriVerifyIssue, MerkleSection, OutOfDomainOpening, Proof, VerifyError, VerifyReport,
-    PROOF_ALPHA_VECTOR_LEN, PROOF_MAX_FRI_LAYERS, PROOF_MAX_QUERY_COUNT, PROOF_MIN_OOD_POINTS,
-    PROOF_TELEMETRY_MAX_CAP_DEGREE, PROOF_TELEMETRY_MAX_CAP_SIZE, PROOF_TELEMETRY_MAX_QUERY_BUDGET,
-    PROOF_VERSION,
-};
+use crate::proof::transcript::TranscriptBlockContext;
+use crate::proof::types::{Proof, VerifyError, VerifyReport};
 use crate::utils::serialization::ProofBytes;
 
-#[derive(Debug, Default, Clone, Copy)]
-struct VerificationStages {
-    params_ok: bool,
-    public_ok: bool,
-    merkle_ok: bool,
-    fri_ok: bool,
-    composition_ok: bool,
+/// Specification describing the single-proof verification flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SingleVerifySpec;
+
+impl SingleVerifySpec {
+    /// Ordered sequence of the verification steps.
+    pub const STEPS: &'static [&'static str] = &["decode", "precheck", "fri_verify", "report"];
 }
 
-/// Verifies a serialized proof against the provided configuration and context.
-pub fn verify_proof_bytes(
-    declared_kind: ConfigProofKind,
-    public_inputs: &PublicInputs<'_>,
-    proof_bytes: &ProofBytes,
-    config: &ProofSystemConfig,
-    context: &VerifierContext,
+/// Skeleton implementation of the single-proof verifier.
+pub fn verify(
+    _declared_kind: ConfigProofKind,
+    _public_inputs: &PublicInputs<'_>,
+    _proof_bytes: &ProofBytes,
+    _config: &ProofSystemConfig,
+    _context: &VerifierContext,
 ) -> Result<VerifyReport, VerifyError> {
-    if (config.proof_version.0 as u16) != PROOF_VERSION {
-        return Err(VerifyError::VersionMismatch {
-            expected: PROOF_VERSION,
-            actual: config.proof_version.0 as u16,
-        });
-    }
-    if config.param_digest != context.param_digest {
-        return Err(VerifyError::ParamsHashMismatch);
-    }
-
-    let proof = Proof::from_bytes(proof_bytes.as_slice())?;
-    let total_bytes = proof_bytes.as_slice().len() as u64;
-    let mut stages = VerificationStages::default();
-    match precheck_decoded_proof(
-        proof,
-        declared_kind,
-        public_inputs,
-        config,
-        context,
-        None,
-        &mut stages,
-    ) {
-        Ok(prechecked) => match execute_fri_stage(&prechecked) {
-            Ok(()) => {
-                stages.fri_ok = true;
-                Ok(build_report(prechecked.proof, stages, total_bytes, None))
-            }
-            Err(error) => Ok(build_report(
-                prechecked.proof,
-                stages,
-                total_bytes,
-                Some(error),
-            )),
-        },
-        Err((proof, error)) => Ok(build_report(proof, stages, total_bytes, Some(error))),
-    }
+    todo!("verify is not implemented yet")
 }
 
+/// Result of the structural pre-checks performed before FRI verification.
 #[derive(Debug, Clone)]
 pub(crate) struct PrecheckedProof {
+    /// Fully decoded proof container.
     pub(crate) proof: Proof,
+    /// Derived FRI seed.
     pub(crate) fri_seed: [u8; 32],
+    /// Security level advertised by the profile.
     pub(crate) security_level: FriSecurityLevel,
 }
 
-fn precheck_decoded_proof(
-    proof: Proof,
-    declared_kind: ConfigProofKind,
-    public_inputs: &PublicInputs<'_>,
-    config: &ProofSystemConfig,
-    context: &VerifierContext,
-    block_context: Option<&TranscriptBlockContext>,
-    stages: &mut VerificationStages,
-) -> Result<PrecheckedProof, (Proof, VerifyError)> {
-    if let Err(error) = validate_header(
-        &proof,
-        declared_kind,
-        public_inputs,
-        config,
-        context,
-        stages,
-    ) {
-        return Err((proof, error));
-    }
-    match precheck_body(&proof, public_inputs, context, block_context, stages) {
-        Ok(prechecked) => Ok(PrecheckedProof {
-            proof,
-            fri_seed: prechecked.fri_seed,
-            security_level: prechecked.security_level,
-        }),
-        Err(error) => Err((proof, error)),
-    }
-}
-
+/// Performs structural checks on the serialized proof before FRI verification.
 pub(crate) fn precheck_proof_bytes(
-    declared_kind: ConfigProofKind,
-    public_inputs: &PublicInputs<'_>,
-    proof_bytes: &ProofBytes,
-    config: &ProofSystemConfig,
-    context: &VerifierContext,
-    block_context: Option<&TranscriptBlockContext>,
+    _declared_kind: ConfigProofKind,
+    _public_inputs: &PublicInputs<'_>,
+    _proof_bytes: &ProofBytes,
+    _config: &ProofSystemConfig,
+    _context: &VerifierContext,
+    _block_context: Option<&TranscriptBlockContext>,
 ) -> Result<PrecheckedProof, VerifyError> {
-    if (config.proof_version.0 as u16) != PROOF_VERSION {
-        return Err(VerifyError::VersionMismatch {
-            expected: PROOF_VERSION,
-            actual: config.proof_version.0 as u16,
-        });
-    }
-    if config.param_digest != context.param_digest {
-        return Err(VerifyError::ParamsHashMismatch);
-    }
-    let proof = Proof::from_bytes(proof_bytes.as_slice())?;
-    let mut stages = VerificationStages::default();
-    precheck_decoded_proof(
-        proof,
-        declared_kind,
-        public_inputs,
-        config,
-        context,
-        block_context,
-        &mut stages,
-    )
-    .map_err(|(_, err)| err)
+    todo!("precheck_proof_bytes is not implemented yet")
 }
 
-pub(crate) fn execute_fri_stage(proof: &PrecheckedProof) -> Result<(), VerifyError> {
-    FriVerifier::verify(
-        &proof.proof.fri_proof,
-        proof.security_level,
-        proof.fri_seed,
-        |index| {
-            proof
-                .proof
-                .fri_proof
-                .final_polynomial
-                .get(index)
-                .copied()
-                .unwrap_or(FieldElement::ZERO)
-        },
-    )
-    .map_err(map_fri_error)
+/// Executes the FRI verification stage for a prechecked proof.
+pub(crate) fn execute_fri_stage(_proof: &PrecheckedProof) -> Result<(), VerifyError> {
+    todo!("execute_fri_stage is not implemented yet")
 }
 
-fn validate_header(
-    proof: &Proof,
-    declared_kind: ConfigProofKind,
-    public_inputs: &PublicInputs<'_>,
-    config: &ProofSystemConfig,
-    context: &VerifierContext,
-    stages: &mut VerificationStages,
-) -> Result<(), VerifyError> {
-    if proof.version != PROOF_VERSION {
-        return Err(VerifyError::VersionMismatch {
-            expected: PROOF_VERSION,
-            actual: proof.version,
-        });
-    }
-
-    let expected_kind = map_public_to_config_kind(public_inputs.kind());
-    if proof.kind != expected_kind || proof.kind != declared_kind {
-        return Err(VerifyError::UnknownProofKind(encode_proof_kind(proof.kind)));
-    }
-
-    if proof.param_digest != config.param_digest {
-        return Err(VerifyError::ParamsHashMismatch);
-    }
-    if proof.param_digest != context.param_digest {
-        return Err(VerifyError::ParamsHashMismatch);
-    }
-
-    let expected_public_inputs = serialize_public_inputs(public_inputs);
-    if proof.public_inputs != expected_public_inputs {
-        return Err(VerifyError::PublicInputMismatch);
-    }
-    stages.public_ok = true;
-
-    let expected_air_spec = resolve_air_spec_id(&context.profile.air_spec_ids, proof.kind);
-    if proof.air_spec_id != expected_air_spec {
-        return Err(VerifyError::UnknownProofKind(encode_proof_kind(proof.kind)));
-    }
-
-    stages.params_ok = true;
-
-    Ok(())
+/// Helper exposing the encode rules for [`ConfigProofKind`].
+pub fn encode_proof_kind(_kind: ConfigProofKind) -> u8 {
+    todo!("encode_proof_kind is not implemented yet")
 }
 
-struct PrecheckedBody {
-    fri_seed: [u8; 32],
-    security_level: FriSecurityLevel,
+/// Resolves the AIR specification identifier from the layout.
+pub fn resolve_air_spec_id(
+    _layout: &ProofKindLayout<AirSpecId>,
+    _kind: ConfigProofKind,
+) -> AirSpecId {
+    todo!("resolve_air_spec_id is not implemented yet")
 }
 
-fn precheck_body(
-    proof: &Proof,
-    public_inputs: &PublicInputs<'_>,
-    context: &VerifierContext,
-    block_context: Option<&TranscriptBlockContext>,
-    stages: &mut VerificationStages,
-) -> Result<PrecheckedBody, VerifyError> {
-    let payload = proof.serialize_payload();
-    let expected_body_length = payload.len() as u32 + 32;
-    if proof.telemetry.body_length != expected_body_length {
-        return Err(VerifyError::BodyLengthMismatch {
-            declared: proof.telemetry.body_length,
-            actual: expected_body_length,
-        });
-    }
-
-    let commitment_digest = compute_commitment_digest(
-        &proof.merkle.core_root,
-        &proof.merkle.aux_root,
-        &proof.merkle.fri_layer_roots,
-    );
-    if proof.commitment_digest.bytes != commitment_digest {
-        return Err(VerifyError::MerkleVerifyFailed {
-            section: MerkleSection::CommitmentDigest,
-        });
-    }
-
-    if proof
-        .fri_proof
-        .layer_roots
-        .first()
-        .copied()
-        .unwrap_or([0u8; 32])
-        != proof.merkle.core_root
-    {
-        return Err(VerifyError::MerkleVerifyFailed {
-            section: MerkleSection::FriRoots,
-        });
-    }
-
-    if proof.merkle.fri_layer_roots != proof.fri_proof.layer_roots {
-        return Err(VerifyError::MerkleVerifyFailed {
-            section: MerkleSection::FriRoots,
-        });
-    }
-
-    stages.merkle_ok = true;
-
-    let transcript_kind = proof.kind;
-    let air_spec_id = resolve_air_spec_id(&context.profile.air_spec_ids, transcript_kind);
-    let mut transcript = Transcript::new(TranscriptHeader {
-        version: context.common_ids.transcript_version_id.clone(),
-        poseidon_param_id: context.profile.poseidon_param_id.clone(),
-        air_spec_id: air_spec_id.clone(),
-        proof_kind: transcript_kind,
-        param_digest: context.param_digest.clone(),
-    })
-    .map_err(|_| VerifyError::TranscriptOrder)?;
-
-    let public_inputs_bytes = serialize_public_inputs(public_inputs);
-    transcript
-        .absorb_public_inputs(&public_inputs_bytes)
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-    transcript
-        .absorb_commitment_roots(proof.merkle.core_root, Some(proof.merkle.aux_root))
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-    transcript
-        .absorb_air_spec_id(air_spec_id)
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-    transcript
-        .absorb_block_context(block_context.cloned())
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-
-    let mut challenges = transcript
-        .finalize()
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-    let alpha_vector = challenges
-        .draw_alpha_vector(PROOF_ALPHA_VECTOR_LEN)
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-    let ood_points = challenges
-        .draw_ood_points(PROOF_MIN_OOD_POINTS)
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-    let _ood_seed = challenges
-        .draw_ood_seed()
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-
-    verify_ood_openings(&proof.openings.out_of_domain, &ood_points, &alpha_vector)?;
-    stages.composition_ok = true;
-
-    let fri_seed = challenges
-        .draw_fri_seed()
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-    for (layer_index, _) in proof.merkle.fri_layer_roots.iter().enumerate() {
-        challenges
-            .draw_fri_eta(layer_index)
-            .map_err(|_| VerifyError::TranscriptOrder)?;
-    }
-    challenges
-        .draw_query_seed()
-        .map_err(|_| VerifyError::TranscriptOrder)?;
-
-    let security_level = map_security_level(&context.profile);
-    if proof.fri_proof.security_level != security_level {
-        return Err(VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::SecurityLevelMismatch,
-        });
-    }
-    if proof.telemetry.fri_parameters.fold != 2
-        || proof.telemetry.fri_parameters.query_budget as usize != security_level.query_budget()
-    {
-        return Err(VerifyError::InvalidFriSection("telemetry".to_string()));
-    }
-
-    if proof.telemetry.fri_parameters.cap_degree > PROOF_TELEMETRY_MAX_CAP_DEGREE
-        || proof.telemetry.fri_parameters.cap_size > PROOF_TELEMETRY_MAX_CAP_SIZE
-        || proof.telemetry.fri_parameters.query_budget > PROOF_TELEMETRY_MAX_QUERY_BUDGET
-    {
-        return Err(VerifyError::InvalidFriSection("telemetry".to_string()));
-    }
-
-    let header_bytes = proof.serialize_header(&payload);
-    if proof.telemetry.header_length != header_bytes.len() as u32 {
-        return Err(VerifyError::HeaderLengthMismatch {
-            declared: proof.telemetry.header_length,
-            actual: header_bytes.len() as u32,
-        });
-    }
-
-    let integrity_digest = compute_integrity_digest(&header_bytes, &payload);
-    if proof.telemetry.integrity_digest.bytes != integrity_digest {
-        return Err(VerifyError::IntegrityDigestMismatch);
-    }
-
-    if proof_size_exceeds_limit(proof, context) {
-        return Err(VerifyError::ProofTooLarge);
-    }
-
-    enforce_resource_limits(proof.kind, public_inputs, context, proof)?;
-
-    Ok(PrecheckedBody {
-        fri_seed,
-        security_level,
-    })
+/// Maps a FRI error into the public [`VerifyError`] variants.
+pub fn map_fri_error(_error: FriError) -> VerifyError {
+    todo!("map_fri_error is not implemented yet")
 }
 
-fn enforce_resource_limits(
-    proof_kind: ConfigProofKind,
-    public_inputs: &PublicInputs<'_>,
-    context: &VerifierContext,
-    proof: &Proof,
-) -> Result<(), VerifyError> {
-    if proof.fri_proof.layer_roots.len() > context.limits.max_layers as usize {
-        return Err(VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::LayerBudgetExceeded,
-        });
-    }
-
-    if proof.fri_proof.layer_roots.len() > PROOF_MAX_FRI_LAYERS {
-        return Err(VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::LayerBudgetExceeded,
-        });
-    }
-
-    if proof.fri_proof.queries.len() > context.limits.max_queries as usize {
-        return Err(VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::QueryOutOfRange,
-        });
-    }
-
-    if proof.fri_proof.queries.len() > PROOF_MAX_QUERY_COUNT {
-        return Err(VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::QueryOutOfRange,
-        });
-    }
-
-    enforce_trace_limits(proof_kind, public_inputs, context)
-}
-
-fn enforce_trace_limits(
-    proof_kind: ConfigProofKind,
-    public_inputs: &PublicInputs<'_>,
-    context: &VerifierContext,
-) -> Result<(), VerifyError> {
-    let width_limit = *context.limits.per_proof_max_trace_width.get(proof_kind) as u32;
-    let step_limit = *context.limits.per_proof_max_trace_steps.get(proof_kind);
-
-    if let PublicInputs::Execution { header, .. } = public_inputs {
-        if header.trace_width > width_limit {
-            return Err(VerifyError::DegreeBoundExceeded);
-        }
-        if header.trace_length > step_limit {
-            return Err(VerifyError::DegreeBoundExceeded);
-        }
-    }
-
-    Ok(())
-}
-
-fn verify_ood_openings(
-    openings: &[OutOfDomainOpening],
-    points: &[[u8; 32]],
-    alphas: &[[u8; 32]],
-) -> Result<(), VerifyError> {
-    if openings.len() != points.len() {
-        return Err(VerifyError::OutOfDomainInvalid);
-    }
-
-    for (index, (opening, point)) in openings.iter().zip(points.iter()).enumerate() {
-        let expected_core = hash_ood_value(b"RPP-OOD/CORE", point, alphas, index);
-        if opening.core_values.len() != 1 || opening.core_values[0] != expected_core {
-            return Err(VerifyError::OutOfDomainInvalid);
-        }
-        if !opening.aux_values.is_empty() {
-            return Err(VerifyError::OutOfDomainInvalid);
-        }
-        let expected_comp = hash_ood_value(b"RPP-OOD/COMP", point, alphas, index);
-        if opening.composition_value != expected_comp {
-            return Err(VerifyError::OutOfDomainInvalid);
-        }
-    }
-
-    Ok(())
-}
-
-fn proof_size_exceeds_limit(proof: &Proof, context: &VerifierContext) -> bool {
-    let payload = proof.serialize_payload();
-    let header_bytes = proof.serialize_header(&payload);
-    let total = header_bytes.len() + payload.len() + 32;
-    total > context.limits.max_proof_size_bytes as usize
-}
-
-fn resolve_air_spec_id(
-    layout: &ProofKindLayout<crate::config::AirSpecId>,
-    kind: ConfigProofKind,
-) -> crate::config::AirSpecId {
-    match kind {
-        ConfigProofKind::Tx => layout.tx.clone(),
-        ConfigProofKind::State => layout.state.clone(),
-        ConfigProofKind::Pruning => layout.pruning.clone(),
-        ConfigProofKind::Uptime => layout.uptime.clone(),
-        ConfigProofKind::Consensus => layout.consensus.clone(),
-        ConfigProofKind::Identity => layout.identity.clone(),
-        ConfigProofKind::Aggregation => layout.aggregation.clone(),
-        ConfigProofKind::VRF => layout.vrf.clone(),
-    }
-}
-
-fn map_security_level(profile: &crate::config::ProfileConfig) -> FriSecurityLevel {
-    match profile.fri_queries {
-        64 => FriSecurityLevel::Standard,
-        96 => FriSecurityLevel::HiSec,
-        48 => FriSecurityLevel::Throughput,
-        _ => FriSecurityLevel::Standard,
-    }
-}
-
-fn build_report(
-    proof: Proof,
-    stages: VerificationStages,
-    total_bytes: u64,
-    error: Option<VerifyError>,
-) -> VerifyReport {
-    VerifyReport {
-        proof,
-        params_ok: stages.params_ok,
-        public_ok: stages.public_ok,
-        merkle_ok: stages.merkle_ok,
-        fri_ok: stages.fri_ok,
-        composition_ok: stages.composition_ok,
-        total_bytes,
-        error,
-    }
-}
-
-fn map_fri_error(error: FriError) -> VerifyError {
-    match error {
-        FriError::EmptyCodeword => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::EmptyCodeword,
-        },
-        FriError::VersionMismatch { .. } => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::VersionMismatch,
-        },
-        FriError::QueryOutOfRange { .. } => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::QueryOutOfRange,
-        },
-        FriError::PathInvalid { .. } => VerifyError::MerkleVerifyFailed {
-            section: MerkleSection::FriPath,
-        },
-        FriError::LayerRootMismatch { .. } => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::LayerMismatch,
-        },
-        FriError::SecurityLevelMismatch => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::SecurityLevelMismatch,
-        },
-        FriError::QueryBudgetMismatch { .. } => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::QueryBudgetMismatch,
-        },
-        FriError::FoldingConstraintViolated { .. } => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::FoldingConstraint,
-        },
-        FriError::OodsInvalid => VerifyError::FriVerifyFailed {
-            issue: FriVerifyIssue::OodsInvalid,
-        },
-        FriError::Serialization(_) => VerifyError::MerkleVerifyFailed {
-            section: MerkleSection::FriPath,
-        },
-        FriError::InvalidStructure(_) => VerifyError::MerkleVerifyFailed {
-            section: MerkleSection::FriPath,
-        },
-    }
-}
-
-fn hash_ood_value(label: &[u8], point: &[u8; 32], alphas: &[[u8; 32]], index: usize) -> [u8; 32] {
-    let mut hasher = Hasher::new();
-    hasher.update(label);
-    hasher.update(point);
-    hasher.update(&(index as u32).to_le_bytes());
-    for alpha in alphas {
-        hasher.update(alpha);
-    }
-    *hasher.finalize().as_bytes()
+/// Placeholder for future telemetry validation.
+pub fn validate_telemetry(_proof: &Proof) -> Result<(), VerifyError> {
+    todo!("validate_telemetry is not implemented yet")
 }

--- a/tests/proof_skeleton_compiles.rs
+++ b/tests/proof_skeleton_compiles.rs
@@ -1,0 +1,83 @@
+use rpp_stark::config::{
+    AirSpecId, ProofKind as ConfigProofKind, ProofSystemConfig, VerifierContext,
+};
+use rpp_stark::fri::{FriProof, FriSecurityLevel};
+use rpp_stark::proof::envelope::ProofBuilder;
+use rpp_stark::proof::public_inputs::PublicInputs;
+use rpp_stark::proof::ser::{serialize_proof, SerError};
+use rpp_stark::proof::types::{
+    FriTelemetry, MerkleProofBundle, Openings, Proof, Telemetry, VerifyError, VerifyReport,
+    PROOF_VERSION,
+};
+use rpp_stark::proof::verify;
+use rpp_stark::utils::serialization::{DigestBytes, ProofBytes};
+
+#[test]
+fn proof_types_can_be_instantiated() {
+    let merkle = MerkleProofBundle {
+        trace_cap: [0u8; 32],
+        composition_cap: [0u8; 32],
+        fri_layers: Vec::new(),
+    };
+    let openings = Openings { trace: Vec::new() };
+    let telemetry = Telemetry {
+        header_bytes: 0,
+        body_bytes: 0,
+        fri: FriTelemetry::default(),
+        integrity_hash: DigestBytes::default(),
+    };
+    let fri_proof = FriProof::new(
+        FriSecurityLevel::Standard,
+        1,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        [0u8; 32],
+        Vec::new(),
+    )
+    .expect("empty skeleton proof");
+
+    let proof = Proof {
+        proof_version: PROOF_VERSION,
+        proof_kind: ConfigProofKind::Tx,
+        params_hash: [0u8; 32],
+        air_spec_id: AirSpecId(DigestBytes::default()),
+        public_inputs: Vec::new(),
+        commitment_digest: DigestBytes::default(),
+        merkle: merkle.clone(),
+        openings: openings.clone(),
+        fri_proof: fri_proof.clone(),
+        telemetry: telemetry.clone(),
+    };
+
+    let _report = VerifyReport {
+        proof: proof.clone(),
+        params_ok: false,
+        public_ok: false,
+        merkle_ok: false,
+        fri_ok: false,
+        composition_ok: false,
+        total_bytes: 0,
+        error: Some(VerifyError::ParamsHashMismatch),
+    };
+
+    let _builder = ProofBuilder::new()
+        .with_proof(proof.clone())
+        .with_merkle(merkle)
+        .with_openings(openings)
+        .with_telemetry(telemetry);
+
+    let _serializer: fn(&Proof) -> Result<Vec<u8>, SerError> = serialize_proof;
+
+    type VerifyFn = fn(
+        ConfigProofKind,
+        &PublicInputs<'_>,
+        &ProofBytes,
+        &ProofSystemConfig,
+        &VerifierContext,
+    ) -> Result<VerifyReport, VerifyError>;
+    let _verify: VerifyFn = verify;
+
+    // Ensure `FriProof` remains accessible for downstream callers.
+    let _ = fri_proof;
+}


### PR DESCRIPTION
## Summary
- align the proof data structures with the new specification (proof_version, params_hash, Openings.trace, telemetry fields, etc.)
- replace the serialization, envelope, and verifier modules with public skeleton signatures and update exports/consumers to the new names
- add a compile-only regression test that instantiates the new proof skeleton types

## Testing
- cargo fmt
- cargo test --test proof_skeleton_compiles

------
https://chatgpt.com/codex/tasks/task_e_68e40beec450832680f2189581c79fa3