### PR TITLE
Implement proof API wiring and lifecycle tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,14 @@ pub mod utils;
 pub mod vrf;
 
 use config::{ProofSystemConfig, ProverContext, VerifierContext};
-use proof::aggregation::{BatchProofRecord, BatchVerificationOutcome};
+use proof::aggregation;
+use proof::prover;
 use proof::public_inputs::PublicInputs;
+use proof::ser::map_public_to_config_kind;
+use proof::types::{FriVerifyIssue, MerkleSection};
 use proof::ProofKind;
 
+pub use proof::aggregation::{BatchProofRecord, BatchVerificationOutcome, BlockContext};
 pub use proof::types::{Proof, Telemetry, VerifyError, VerifyReport, PROOF_VERSION};
 use utils::serialization::{ProofBytes, WitnessBlob};
 
@@ -88,8 +92,13 @@ pub fn generate_proof(
     config: &ProofSystemConfig,
     prover_context: &ProverContext,
 ) -> StarkResult<ProofBytes> {
-    let _ = (kind, public_inputs, witness, config, prover_context);
-    Err(StarkError::NotImplemented("generate_proof contract only"))
+    if kind != public_inputs.kind() {
+        return Err(StarkError::InvalidInput("proof_kind_mismatch"));
+    }
+
+    let envelope = prover::build_envelope(public_inputs, witness, config, prover_context)
+        .map_err(map_prover_error)?;
+    Ok(ProofBytes::new(envelope.to_bytes()))
 }
 
 /// Verifies a single proof and returns a [`VerificationVerdict`].
@@ -105,8 +114,24 @@ pub fn verify_proof(
     config: &ProofSystemConfig,
     verifier_context: &VerifierContext,
 ) -> StarkResult<VerificationVerdict> {
-    let _ = (kind, public_inputs, proof_bytes, config, verifier_context);
-    Err(StarkError::NotImplemented("verify_proof contract only"))
+    if kind != public_inputs.kind() {
+        return Err(StarkError::InvalidInput("proof_kind_mismatch"));
+    }
+
+    let declared_kind = map_public_to_config_kind(kind);
+    match proof::verifier::verify_proof_bytes(
+        declared_kind,
+        public_inputs,
+        proof_bytes,
+        config,
+        verifier_context,
+    ) {
+        Ok(report) => Ok(match report.error {
+            None => VerificationVerdict::Accept,
+            Some(error) => VerificationVerdict::Reject(error),
+        }),
+        Err(error) => Err(map_verify_error(error)),
+    }
 }
 
 /// Verifies a batch of proofs under a shared block context.
@@ -121,11 +146,91 @@ pub fn batch_verify(
     config: &ProofSystemConfig,
     verifier_context: &VerifierContext,
 ) -> StarkResult<BatchVerificationOutcome> {
-    let _ = (block_context, proofs, config, verifier_context);
-    Err(StarkError::NotImplemented("batch_verify contract only"))
+    for record in proofs {
+        if record.kind != record.public_inputs.kind() {
+            return Err(StarkError::InvalidInput("proof_kind_mismatch"));
+        }
+    }
+
+    let outcome = aggregation::batch_verify(block_context, proofs, config, verifier_context);
+    Ok(outcome)
 }
 
 /// Convenience helper describing the canonical proof envelope layout.
 pub fn proof_envelope_spec() -> &'static str {
     "See proof::types::Proof and proof::ser for the canonical layout implementation."
+}
+
+fn map_prover_error(error: prover::ProverError) -> StarkError {
+    use prover::ProverError;
+
+    match error {
+        ProverError::UnsupportedProofVersion(_) => {
+            StarkError::InvalidInput("unsupported_proof_version")
+        }
+        ProverError::ParamDigestMismatch => {
+            StarkError::InvalidInput("prover_param_digest_mismatch")
+        }
+        ProverError::MalformedWitness(reason) => StarkError::InvalidInput(reason),
+        ProverError::Transcript(_) => StarkError::SubsystemFailure("prover_transcript_error"),
+        ProverError::Fri(_) => StarkError::SubsystemFailure("prover_fri_error"),
+        ProverError::ProofTooLarge { .. } => StarkError::InvalidInput("proof_too_large"),
+    }
+}
+
+fn map_verify_error(error: VerifyError) -> StarkError {
+    match error {
+        VerifyError::VersionMismatch { .. } => StarkError::InvalidInput("version_mismatch"),
+        VerifyError::UnknownProofKind(_) => StarkError::InvalidInput("unknown_proof_kind"),
+        VerifyError::HeaderLengthMismatch { .. } => {
+            StarkError::InvalidInput("header_length_mismatch")
+        }
+        VerifyError::BodyLengthMismatch { .. } => StarkError::InvalidInput("body_length_mismatch"),
+        VerifyError::UnexpectedEndOfBuffer(_) => {
+            StarkError::InvalidInput("unexpected_end_of_buffer")
+        }
+        VerifyError::IntegrityDigestMismatch => {
+            StarkError::InvalidInput("integrity_digest_mismatch")
+        }
+        VerifyError::InvalidFriSection(_) => StarkError::InvalidInput("invalid_fri_section"),
+        VerifyError::NonCanonicalFieldElement => {
+            StarkError::InvalidInput("non_canonical_field_element")
+        }
+        VerifyError::ParamsHashMismatch => StarkError::InvalidInput("param_digest_mismatch"),
+        VerifyError::PublicInputMismatch => StarkError::InvalidInput("public_input_mismatch"),
+        VerifyError::TranscriptOrder => StarkError::InvalidInput("transcript_order"),
+        VerifyError::OutOfDomainInvalid => StarkError::InvalidInput("out_of_domain_invalid"),
+        VerifyError::MerkleVerifyFailed { section } => match section {
+            MerkleSection::CommitmentDigest => StarkError::InvalidInput("merkle_commitment_digest"),
+            MerkleSection::FriRoots => StarkError::InvalidInput("merkle_fri_roots"),
+            MerkleSection::FriPath => StarkError::InvalidInput("merkle_fri_path"),
+        },
+        VerifyError::FriVerifyFailed { issue } => match issue {
+            FriVerifyIssue::QueryOutOfRange => StarkError::InvalidInput("fri_query_out_of_range"),
+            FriVerifyIssue::PathInvalid => StarkError::InvalidInput("fri_path_invalid"),
+            FriVerifyIssue::LayerMismatch => StarkError::InvalidInput("fri_layer_mismatch"),
+            FriVerifyIssue::SecurityLevelMismatch => {
+                StarkError::InvalidInput("fri_security_level_mismatch")
+            }
+            FriVerifyIssue::LayerBudgetExceeded => {
+                StarkError::InvalidInput("fri_layer_budget_exceeded")
+            }
+            FriVerifyIssue::EmptyCodeword => StarkError::InvalidInput("fri_empty_codeword"),
+            FriVerifyIssue::VersionMismatch => StarkError::InvalidInput("fri_version_mismatch"),
+            FriVerifyIssue::QueryBudgetMismatch => {
+                StarkError::InvalidInput("fri_query_budget_mismatch")
+            }
+            FriVerifyIssue::FoldingConstraint => StarkError::InvalidInput("fri_folding_constraint"),
+            FriVerifyIssue::OodsInvalid => StarkError::InvalidInput("fri_oods_invalid"),
+            FriVerifyIssue::Generic => StarkError::InvalidInput("fri_generic_failure"),
+        },
+        VerifyError::DegreeBoundExceeded => StarkError::InvalidInput("degree_bound_exceeded"),
+        VerifyError::ProofTooLarge => StarkError::InvalidInput("proof_too_large"),
+        VerifyError::EmptyOpenings => StarkError::InvalidInput("empty_openings"),
+        VerifyError::IndicesDuplicate => StarkError::InvalidInput("indices_duplicate"),
+        VerifyError::AggregationDigestMismatch => {
+            StarkError::InvalidInput("aggregation_digest_mismatch")
+        }
+        VerifyError::Serialization(_) => StarkError::InvalidInput("serialization_error"),
+    }
 }

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -1,0 +1,254 @@
+use rpp_stark::config::{
+    build_proof_system_config, build_prover_context, build_verifier_context, compute_param_digest,
+    ChunkingPolicy, CommonIdentifiers, ParamDigest, ProfileConfig, ProofSystemConfig,
+    ProverContext, ThreadPoolProfile, VerifierContext, COMMON_IDENTIFIERS, PROFILE_STANDARD_CONFIG,
+};
+use rpp_stark::proof::public_inputs::{
+    ExecutionHeaderV1, ProofKind, PublicInputVersion, PublicInputs,
+};
+use rpp_stark::proof::types::{VerifyError, PROOF_VERSION};
+use rpp_stark::utils::serialization::{DigestBytes, ProofBytes, WitnessBlob};
+use rpp_stark::{
+    batch_verify, generate_proof, verify_proof, BatchProofRecord, BatchVerificationOutcome,
+    BlockContext, StarkError, VerificationVerdict,
+};
+
+struct TestSetup {
+    config: ProofSystemConfig,
+    prover_context: ProverContext,
+    verifier_context: VerifierContext,
+    header: ExecutionHeaderV1,
+    body: Vec<u8>,
+    witness: Vec<u8>,
+}
+
+impl TestSetup {
+    fn new() -> Self {
+        let profile: ProfileConfig = PROFILE_STANDARD_CONFIG.clone();
+        let common: CommonIdentifiers = COMMON_IDENTIFIERS.clone();
+        let param_digest = compute_param_digest(&profile, &common);
+        let config = build_proof_system_config(&profile, &param_digest);
+        let prover_context = build_prover_context(
+            &profile,
+            &common,
+            &param_digest,
+            ThreadPoolProfile::SingleThread,
+            ChunkingPolicy {
+                min_chunk_items: 4,
+                max_chunk_items: 32,
+                stride: 1,
+            },
+        );
+        let verifier_context = build_verifier_context(&profile, &common, &param_digest, None);
+
+        let header = ExecutionHeaderV1 {
+            version: PublicInputVersion::V1,
+            program_digest: DigestBytes { bytes: [0u8; 32] },
+            trace_length: 128,
+            trace_width: 4,
+        };
+        let body = Vec::new();
+        let witness = build_witness(128);
+
+        Self {
+            config,
+            prover_context,
+            verifier_context,
+            header,
+            body,
+            witness,
+        }
+    }
+}
+
+fn build_witness(count: usize) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(4 + count * 8);
+    bytes.extend_from_slice(&(count as u32).to_le_bytes());
+    for value in 0..count {
+        bytes.extend_from_slice(&((value as u64 + 1).to_le_bytes()));
+    }
+    bytes
+}
+
+fn make_public_inputs<'a>(header: &'a ExecutionHeaderV1, body: &'a [u8]) -> PublicInputs<'a> {
+    PublicInputs::Execution {
+        header: header.clone(),
+        body,
+    }
+}
+
+#[test]
+fn proof_lifecycle_accepts_valid_inputs() {
+    let setup = TestSetup::new();
+    let witness = WitnessBlob {
+        bytes: &setup.witness,
+    };
+
+    let public_inputs = make_public_inputs(&setup.header, &setup.body);
+    let proof = generate_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        witness,
+        &setup.config,
+        &setup.prover_context,
+    )
+    .expect("proof generation succeeds");
+    let decoded = rpp_stark::Proof::from_bytes(proof.as_slice()).expect("decode proof");
+    assert_eq!(
+        decoded.fri_proof.queries.len(),
+        setup.config.profile.fri_queries as usize,
+        "unexpected query count"
+    );
+
+    let verify_inputs = make_public_inputs(&setup.header, &setup.body);
+    let verdict = verify_proof(
+        ProofKind::Execution,
+        &verify_inputs,
+        &proof,
+        &setup.config,
+        &setup.verifier_context,
+    )
+    .expect("verification verdict");
+    match verdict {
+        VerificationVerdict::Accept => {}
+        VerificationVerdict::Reject(err) => {
+            panic!("expected verification to accept, got {:?}", err);
+        }
+    }
+}
+
+#[test]
+fn verification_rejects_mismatched_public_inputs() {
+    let setup = TestSetup::new();
+    let witness = WitnessBlob {
+        bytes: &setup.witness,
+    };
+    let public_inputs = make_public_inputs(&setup.header, &setup.body);
+    let proof = generate_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        witness,
+        &setup.config,
+        &setup.prover_context,
+    )
+    .expect("proof generation succeeds");
+
+    let mut mismatched_header = setup.header.clone();
+    mismatched_header.trace_length += 1;
+    let bad_inputs = make_public_inputs(&mismatched_header, &setup.body);
+    let verdict = verify_proof(
+        ProofKind::Execution,
+        &bad_inputs,
+        &proof,
+        &setup.config,
+        &setup.verifier_context,
+    )
+    .expect("verification verdict");
+    assert!(matches!(
+        verdict,
+        VerificationVerdict::Reject(VerifyError::PublicInputMismatch)
+    ));
+
+    let record = BatchProofRecord {
+        kind: ProofKind::Execution,
+        public_inputs: &bad_inputs,
+        proof_bytes: &proof,
+    };
+    let block_context = BlockContext {
+        block_height: 7,
+        previous_state_root: [1u8; 32],
+        network_id: 7,
+    };
+    let outcome = batch_verify(
+        &block_context,
+        &[record],
+        &setup.config,
+        &setup.verifier_context,
+    )
+    .expect("batch verification");
+    assert!(matches!(
+        outcome,
+        BatchVerificationOutcome::Reject {
+            failing_proof_index: 0,
+            error: VerifyError::PublicInputMismatch,
+        }
+    ));
+}
+
+#[test]
+fn batch_verify_accepts_empty_batch() {
+    let setup = TestSetup::new();
+    let block_context = BlockContext {
+        block_height: 0,
+        previous_state_root: [0u8; 32],
+        network_id: 0,
+    };
+    let outcome = batch_verify(&block_context, &[], &setup.config, &setup.verifier_context)
+        .expect("empty batch should succeed");
+    assert_eq!(outcome, BatchVerificationOutcome::Accept);
+}
+
+#[test]
+fn generate_proof_propagates_param_digest_mismatch() {
+    let setup = TestSetup::new();
+    let mut wrong_config = setup.config.clone();
+    wrong_config.param_digest = ParamDigest(DigestBytes { bytes: [1u8; 32] });
+
+    let witness = WitnessBlob {
+        bytes: &setup.witness,
+    };
+    let public_inputs = make_public_inputs(&setup.header, &setup.body);
+
+    let error = generate_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        witness,
+        &wrong_config,
+        &setup.prover_context,
+    )
+    .expect_err("param digest mismatch propagates");
+    assert!(matches!(
+        error,
+        StarkError::InvalidInput("prover_param_digest_mismatch")
+    ));
+}
+
+#[test]
+fn verify_proof_reports_decode_failures() {
+    let setup = TestSetup::new();
+    let witness = WitnessBlob {
+        bytes: &setup.witness,
+    };
+    let public_inputs = make_public_inputs(&setup.header, &setup.body);
+    let proof = generate_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        witness,
+        &setup.config,
+        &setup.prover_context,
+    )
+    .expect("proof generation succeeds");
+
+    let mut corrupted_bytes = proof.as_slice().to_vec();
+    if let Some(first) = corrupted_bytes.first_mut() {
+        *first ^= 0xFF;
+    }
+    let corrupted = ProofBytes::new(corrupted_bytes);
+    let verify_inputs = make_public_inputs(&setup.header, &setup.body);
+    let result = verify_proof(
+        ProofKind::Execution,
+        &verify_inputs,
+        &corrupted,
+        &setup.config,
+        &setup.verifier_context,
+    );
+
+    match result.expect_err("verification should fail") {
+        StarkError::InvalidInput(label) => {
+            assert_eq!(label, "version_mismatch");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    assert_eq!(PROOF_VERSION, setup.config.proof_version.0 as u16);
+}


### PR DESCRIPTION
## Summary
- implement the public proof lifecycle functions using the prover, verifier, and aggregation modules
- forward the documentation-layer API stubs to the concrete implementations with explicit error mapping
- add integration tests covering positive and negative proof verification and batch flows

## Testing
- cargo test proof_lifecycle

------
https://chatgpt.com/codex/tasks/task_e_68e5769e350483268690e33251627d98