### PR TITLE
Add support for quaternary Merkle paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,14 @@ profiles:
 | `PROFILE_X8` | Goldilocks | Poseidon2 (set 0) | 8 | 30 | Binary | 96 |
 | `PROFILE_HISEC_X16` | BN254 | Rescue (set 1) | 16 | 48 | Quaternary | 128 |
 
+In addition to the builder presets, the proof system exposes deterministic
+`ProfileConfig` descriptors.  The default rollup pipeline now ships with both a
+binary and a quaternary Merkle configuration: `PROFILE_STANDARD_CONFIG`
+(`COMMON_IDENTIFIERS`) and `PROFILE_STANDARD_ARITY4_CONFIG`
+(`COMMON_IDENTIFIERS_ARITY4`).  Switching between them adjusts the Merkle
+branching factor without affecting the transcript, hashing backend or AIR
+parameters.
+
 ### Canonical byte layout
 
 The binary format is free of padding and all integers are little-endian:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,6 +46,9 @@ pub const PROFILE_HISEC: ProfileId = ProfileId(2);
 /// queries. Integrators **must** benchmark before enabling it.
 pub const PROFILE_THROUGHPUT: ProfileId = ProfileId(3);
 
+/// Standard proving profile using quaternary Merkle trees.
+pub const PROFILE_STD_ARITY4: ProfileId = ProfileId(4);
+
 /// Identifier describing the base field of the AIR.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FieldId(pub u8);
@@ -492,6 +495,12 @@ pub const MERKLE_SCHEME_ID_BLAKE3_2ARY_V1: MerkleSchemeId = MerkleSchemeId(diges
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ]));
 
+/// Canonical Merkle scheme identifier (`BLAKE3_4ARY_V1`).
+pub const MERKLE_SCHEME_ID_BLAKE3_4ARY_V1: MerkleSchemeId = MerkleSchemeId(digest([
+    b'B', b'L', b'A', b'K', b'E', b'3', b'_', b'4', b'A', b'R', b'Y', b'_', b'V', b'1', 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+]));
+
 /// Canonical transcript identifier (`RPP_FS_V1`).
 pub const TRANSCRIPT_VERSION_ID_RPP_FS_V1: TranscriptVersionId = TranscriptVersionId(digest([
     b'R', b'P', b'P', b'_', b'F', b'S', b'_', b'V', b'1', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -560,6 +569,14 @@ pub const COMMON_IDENTIFIERS: CommonIdentifiers = CommonIdentifiers {
     fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
 };
 
+/// Common identifiers variant using quaternary Merkle commitments.
+pub const COMMON_IDENTIFIERS_ARITY4: CommonIdentifiers = CommonIdentifiers {
+    field_id: FIELD_ID_GOLDILOCKS_64,
+    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_4ARY_V1,
+    transcript_version_id: TRANSCRIPT_VERSION_ID_RPP_FS_V1,
+    fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
+};
+
 /// Standard profile configuration (`PROFILE_STD`).
 pub const PROFILE_STANDARD_CONFIG: ProfileConfig = ProfileConfig {
     id: PROFILE_STD,
@@ -574,6 +591,52 @@ pub const PROFILE_STANDARD_CONFIG: ProfileConfig = ProfileConfig {
     },
     poseidon_param_id: POSEIDON_PARAM_ID_STANDARD,
     merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_2ARY_V1,
+    transcript_version_id: TRANSCRIPT_VERSION_ID_RPP_FS_V1,
+    fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
+    batch_verification_enabled: true,
+    max_threads: 8,
+    limits: ResourceLimits {
+        max_proof_size_bytes: 1_500_000,
+        max_layers: 16,
+        max_queries: 96,
+        per_proof_max_trace_width: ProofKindLayout {
+            tx: 64,
+            state: 128,
+            pruning: 96,
+            uptime: 48,
+            consensus: 96,
+            identity: 64,
+            aggregation: 160,
+            vrf: 48,
+        },
+        per_proof_max_trace_steps: ProofKindLayout {
+            tx: 1_048_576,
+            state: 4_194_304,
+            pruning: 2_097_152,
+            uptime: 524_288,
+            consensus: 1_048_576,
+            identity: 262_144,
+            aggregation: 1_048_576,
+            vrf: 131_072,
+        },
+    },
+    air_spec_ids: AIR_SPEC_IDS_V1,
+};
+
+/// Standard profile using the quaternary Merkle commitment scheme.
+pub const PROFILE_STANDARD_ARITY4_CONFIG: ProfileConfig = ProfileConfig {
+    id: PROFILE_STD_ARITY4,
+    name: "standard-arity4",
+    security_goal: "80-bit query soundness with quaternary Merkle commitments",
+    lde_factor: 8,
+    fri_queries: 64,
+    fri_depth_range: FriDepthRange { min: 8, max: 12 },
+    poseidon_rounds: PoseidonRoundConfiguration {
+        full_rounds: 8,
+        partial_rounds: 56,
+    },
+    poseidon_param_id: POSEIDON_PARAM_ID_STANDARD,
+    merkle_scheme_id: MERKLE_SCHEME_ID_BLAKE3_4ARY_V1,
     transcript_version_id: TRANSCRIPT_VERSION_ID_RPP_FS_V1,
     fri_plan_id: FRI_PLAN_ID_FOLD2_V1,
     batch_verification_enabled: true,

--- a/src/proof/params.rs
+++ b/src/proof/params.rs
@@ -1,5 +1,8 @@
-use crate::config::{ProfileConfig, PROFILE_HIGH_SECURITY_CONFIG, PROFILE_STANDARD_CONFIG};
-use crate::params::{FriFolding, HashKind, LdeOrder, StarkParams, StarkParamsBuilder};
+use crate::config::{
+    ProfileConfig, MERKLE_SCHEME_ID_BLAKE3_4ARY_V1, PROFILE_HIGH_SECURITY_CONFIG,
+    PROFILE_STANDARD_CONFIG,
+};
+use crate::params::{FriFolding, HashKind, LdeOrder, MerkleArity, StarkParams, StarkParamsBuilder};
 
 /// Returns the canonical Stark parameter set shared by prover and verifier.
 ///
@@ -12,6 +15,11 @@ pub fn canonical_stark_params(profile: &ProfileConfig) -> StarkParams {
     let mut builder = StarkParamsBuilder::new();
     builder.hash = HashKind::Blake2s { digest_size: 32 };
     builder.merkle.leaf_width = 1;
+    if profile.merkle_scheme_id == MERKLE_SCHEME_ID_BLAKE3_4ARY_V1 {
+        builder.merkle.arity = MerkleArity::Quaternary;
+    } else {
+        builder.merkle.arity = MerkleArity::Binary;
+    }
     builder.lde.blowup = profile.lde_factor as u32;
     builder.fri.queries = profile.fri_queries;
     builder.fri.domain_log2 = profile.fri_depth_range.max as u16;

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -714,7 +714,7 @@ fn convert_path(
                     if node.index >= branching || node.index == first.index {
                         return Err(VerifyError::MerkleVerifyFailed { section });
                     }
-                    if !missing_positions.iter().any(|&pos| pos == node.index) {
+                    if !missing_positions.contains(&node.index) {
                         return Err(VerifyError::MerkleVerifyFailed { section });
                     }
                     if seen[node.index as usize] {

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -539,13 +539,29 @@ fn convert_tree_proof(proof: &MerkleProof, index: u32) -> MerkleAuthenticationPa
             }
             ProofNode::Arity4(digests) => {
                 let position = (current % arity) as u8;
-                let sibling_index = (position as usize)
-                    .saturating_sub(1)
-                    .min(digests.len().saturating_sub(1));
-                nodes.push(MerklePathNode {
-                    index: position,
-                    sibling: digest_to_array(digests[sibling_index].as_bytes()),
-                });
+                let branching = proof.arity.as_usize() as u8;
+                let missing_positions: Vec<u8> =
+                    (0..branching).filter(|pos| *pos != position).collect();
+                let mut digest_iter = digests.iter();
+
+                if let Some(first_digest) = digest_iter.next() {
+                    nodes.push(MerklePathNode {
+                        index: position,
+                        sibling: digest_to_array(first_digest.as_bytes()),
+                    });
+                } else {
+                    nodes.push(MerklePathNode {
+                        index: position,
+                        sibling: [0u8; 32],
+                    });
+                }
+
+                for (pos, digest) in missing_positions.iter().skip(1).zip(digest_iter) {
+                    nodes.push(MerklePathNode {
+                        index: *pos,
+                        sibling: digest_to_array(digest.as_bytes()),
+                    });
+                }
             }
         }
         if arity > 0 {

--- a/tests/proof_merkle_quaternary.rs
+++ b/tests/proof_merkle_quaternary.rs
@@ -1,0 +1,164 @@
+use rpp_stark::config::{
+    build_proof_system_config, build_prover_context, build_verifier_context, compute_param_digest,
+    ChunkingPolicy, ProofSystemConfig, ProverContext, ThreadPoolProfile, VerifierContext,
+    COMMON_IDENTIFIERS_ARITY4, PROFILE_STANDARD_ARITY4_CONFIG,
+};
+use rpp_stark::field::prime_field::{CanonicalSerialize, FieldElementOps};
+use rpp_stark::field::FieldElement;
+use rpp_stark::proof::public_inputs::{
+    ExecutionHeaderV1, ProofKind, PublicInputVersion, PublicInputs,
+};
+use rpp_stark::proof::ser::serialize_proof;
+use rpp_stark::proof::types::{MerkleSection, VerifyError};
+use rpp_stark::utils::serialization::{DigestBytes, ProofBytes, WitnessBlob};
+use rpp_stark::{generate_proof, verify_proof, Proof, VerificationVerdict};
+
+const LFSR_ALPHA: u64 = 5;
+const LFSR_BETA: u64 = 7;
+
+fn build_setup() -> (
+    ProofSystemConfig,
+    ProverContext,
+    VerifierContext,
+    ExecutionHeaderV1,
+    Vec<u8>,
+    Vec<u8>,
+) {
+    let profile = PROFILE_STANDARD_ARITY4_CONFIG.clone();
+    let common = COMMON_IDENTIFIERS_ARITY4;
+    let param_digest = compute_param_digest(&profile, &common);
+    let config = build_proof_system_config(&profile, &param_digest);
+    let prover_context = build_prover_context(
+        &profile,
+        &common,
+        &param_digest,
+        ThreadPoolProfile::SingleThread,
+        ChunkingPolicy {
+            min_chunk_items: 4,
+            max_chunk_items: 32,
+            stride: 1,
+        },
+    );
+    let verifier_context = build_verifier_context(&profile, &common, &param_digest, None);
+
+    let seed = FieldElement::from(3u64);
+    let length = 128usize;
+    let header = ExecutionHeaderV1 {
+        version: PublicInputVersion::V1,
+        program_digest: DigestBytes { bytes: [0u8; 32] },
+        trace_length: length as u32,
+        trace_width: 1,
+    };
+    let body = seed.to_bytes().to_vec();
+    let witness = build_witness(seed, length);
+
+    (
+        config,
+        prover_context,
+        verifier_context,
+        header,
+        body,
+        witness,
+    )
+}
+
+fn build_witness(seed: FieldElement, rows: usize) -> Vec<u8> {
+    let alpha = FieldElement::from(LFSR_ALPHA);
+    let beta = FieldElement::from(LFSR_BETA);
+    let mut column = Vec::with_capacity(rows);
+    let mut state = seed;
+    column.push(state);
+    for _ in 1..rows {
+        state = state.mul(&alpha).add(&beta);
+        column.push(state);
+    }
+
+    let mut bytes = Vec::with_capacity(20 + rows * 8);
+    bytes.extend_from_slice(&(rows as u32).to_le_bytes());
+    bytes.extend_from_slice(&1u32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    for value in column {
+        bytes.extend_from_slice(&value.to_bytes());
+    }
+    bytes
+}
+
+fn make_public_inputs<'a>(header: &'a ExecutionHeaderV1, body: &'a [u8]) -> PublicInputs<'a> {
+    PublicInputs::Execution {
+        header: header.clone(),
+        body,
+    }
+}
+
+#[test]
+fn quaternary_profile_roundtrip_accepts() {
+    let (config, prover_context, verifier_context, header, body, witness) = build_setup();
+    let witness_blob = WitnessBlob { bytes: &witness };
+    let public_inputs = make_public_inputs(&header, &body);
+
+    let proof_bytes = generate_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        witness_blob,
+        &config,
+        &prover_context,
+    )
+    .expect("proof generation succeeds");
+
+    let verdict = verify_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        &proof_bytes,
+        &config,
+        &verifier_context,
+    )
+    .expect("verification executes");
+
+    assert!(matches!(verdict, VerificationVerdict::Accept));
+}
+
+#[test]
+fn quaternary_profile_merkle_tamper_rejected() {
+    let (config, prover_context, verifier_context, header, body, witness) = build_setup();
+    let public_inputs = make_public_inputs(&header, &body);
+    let proof_bytes = generate_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        WitnessBlob { bytes: &witness },
+        &config,
+        &prover_context,
+    )
+    .expect("proof generation succeeds");
+
+    let mut proof = Proof::from_bytes(proof_bytes.as_slice()).expect("decode proof");
+    if let Some(path) = proof.openings.trace.paths.first_mut() {
+        if let Some(node) = path.nodes.get_mut(1) {
+            node.sibling[0] ^= 0x01;
+        }
+    }
+    let tampered_bytes =
+        ProofBytes::new(serialize_proof(&proof).expect("serialize tampered proof"));
+
+    let verdict = verify_proof(
+        ProofKind::Execution,
+        &public_inputs,
+        &tampered_bytes,
+        &config,
+        &verifier_context,
+    )
+    .expect("verification executes");
+
+    match verdict {
+        VerificationVerdict::Reject(error) => {
+            assert!(matches!(
+                error,
+                VerifyError::MerkleVerifyFailed {
+                    section: MerkleSection::TraceCommit
+                }
+            ));
+        }
+        other => panic!("expected rejection, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- add a BLAKE3-based arity-4 Merkle scheme along with matching profile and identifier constants
- update the prover and verifier to emit and check quaternary authentication paths while retaining binary support
- extend the documentation and tests to cover arity-4 commit/open/verify flows and negative cases

## Testing
- cargo test --test merkle_roundtrip
- cargo test --test proof_merkle_quaternary

------
https://chatgpt.com/codex/tasks/task_e_68e681036ed883269acb3f7bab1cefc0