### PR TITLE
Make proof serialization fallible

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -121,7 +121,7 @@ fn sample_hash(
     run_label: &str,
 ) -> (String, usize) {
     let proof = build_sample_proof(profile, param_digest, run_label);
-    let bytes = proof.to_bytes();
+    let bytes = proof.to_bytes().expect("serialize proof");
     let digest = hash(&bytes);
     (format!("{}", digest.to_hex()), bytes.len())
 }

--- a/src/proof/api.rs
+++ b/src/proof/api.rs
@@ -132,7 +132,8 @@ pub fn generate_proof(
 
     let proof = prover::build_envelope(public_inputs, witness, config, prover_context)
         .map_err(map_prover_error_to_verify)?;
-    Ok(ProofBytes::new(proof.to_bytes()))
+    let bytes = proof.to_bytes()?;
+    Ok(ProofBytes::new(bytes))
 }
 
 /// Forward declaration of the verify_proof function (no implementation).

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -18,7 +18,7 @@ use crate::proof::ser::{
 use crate::proof::types::{
     MerkleProofBundle, MerkleSection, Openings, OutOfDomainOpening, Proof, Telemetry, VerifyError,
 };
-use crate::ser::SerKind;
+use crate::ser::{SerError, SerKind};
 use crate::{
     config::{AirSpecId, ParamDigest, ProofKind},
     fri::FriProof,
@@ -228,8 +228,10 @@ fn ensure_sorted_indices(fri_proof: &FriProof) -> Result<(), VerifyError> {
 
 impl Proof {
     /// Serialises the proof into a byte vector using the canonical layout.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        serialize_proof(self).expect("proof serialization should succeed for well-formed envelopes")
+    ///
+    /// Returns an error if canonical serialization fails.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, SerError> {
+        serialize_proof(self)
     }
 
     /// Parses an envelope from a byte slice, validating all length prefixes and
@@ -467,7 +469,7 @@ mod tests {
     #[test]
     fn proof_round_trip() {
         let proof = build_sample_proof();
-        let bytes = proof.to_bytes();
+        let bytes = proof.to_bytes().expect("serialize proof");
         let decoded = Proof::from_bytes(&bytes).expect("decode proof");
         assert_eq!(proof, decoded);
     }

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -351,7 +351,7 @@ fn build_envelope(
     let integrity = compute_integrity_digest(&header_bytes, &payload);
     proof.telemetry.integrity_digest = DigestBytes { bytes: integrity };
 
-    ProofBytes::new(proof.to_bytes())
+    ProofBytes::new(proof.to_bytes().expect("serialize proof"))
 }
 
 fn build_queries(layer_count: usize, indices: &[u32]) -> Vec<FriQueryProof> {


### PR DESCRIPTION
## Summary
- make `Proof::to_bytes` return a `Result` and forward the serialization helper directly
- update public APIs, binaries, and tests to handle fallible proof serialization
- map serialization failures into the exported error types

## Testing
- cargo fmt
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68e68f12499c8326adae463dafa5f0a1