### PR TITLE
Handle serialization errors when building proofs

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -209,8 +209,12 @@ fn build_sample_proof(
         telemetry,
     };
 
-    let payload = proof.serialize_payload();
-    let header_bytes = proof.serialize_header(&payload);
+    let payload = proof
+        .serialize_payload()
+        .expect("sample proof payload serialization");
+    let header_bytes = proof
+        .serialize_header(&payload)
+        .expect("sample proof header serialization");
     proof.telemetry.body_length = (payload.len() + 32) as u32;
     proof.telemetry.header_length = header_bytes.len() as u32;
     let integrity = compute_integrity_digest(&header_bytes, &payload);
@@ -236,7 +240,7 @@ fn sample_public_inputs(profile: &ProfileConfig, run_label: &str) -> Vec<u8> {
         header,
         body: body.as_bytes(),
     };
-    serialize_public_inputs(&inputs)
+    serialize_public_inputs(&inputs).expect("sample public inputs serialization")
 }
 
 fn sample_reader(profile_id: ProfileId, run_label: &str) -> OutputReader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,9 @@ fn map_prover_error(error: prover::ProverError) -> StarkError {
         ProverError::Air(_) => StarkError::SubsystemFailure("prover_air_error"),
         ProverError::Merkle(_) => StarkError::SubsystemFailure("prover_merkle_error"),
         ProverError::ProofTooLarge { .. } => StarkError::InvalidInput("proof_too_large"),
+        ProverError::Serialization(kind) => {
+            map_serialization_error(SerError::invalid_value(kind, "prover_serialization"))
+        }
     }
 }
 

--- a/src/proof/api.rs
+++ b/src/proof/api.rs
@@ -200,5 +200,6 @@ fn map_prover_error_to_verify(error: prover::ProverError) -> VerifyError {
             section: MerkleSection::FriPath,
         },
         ProverError::ProofTooLarge { .. } => VerifyError::ProofTooLarge,
+        ProverError::Serialization(kind) => VerifyError::Serialization(kind),
     }
 }

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -205,7 +205,8 @@ fn build_envelope(
     final_poly_len: usize,
 ) -> ProofBytes {
     let public_inputs = inputs.as_public_inputs();
-    let public_inputs_bytes = serialize_public_inputs(&public_inputs);
+    let public_inputs_bytes =
+        serialize_public_inputs(&public_inputs).expect("public inputs serialization");
     let public_digest = compute_public_digest(&public_inputs_bytes);
 
     let proof_kind = ConfigProofKind::Tx;
@@ -344,8 +345,12 @@ fn build_envelope(
         telemetry,
     };
 
-    let payload = proof.serialize_payload();
-    let header_bytes = proof.serialize_header(&payload);
+    let payload = proof
+        .serialize_payload()
+        .expect("proof payload serialization");
+    let header_bytes = proof
+        .serialize_header(&payload)
+        .expect("proof header serialization");
     proof.telemetry.body_length = (payload.len() + 32) as u32;
     proof.telemetry.header_length = header_bytes.len() as u32;
     let integrity = compute_integrity_digest(&header_bytes, &payload);
@@ -391,7 +396,7 @@ fn build_ood_openings(
     })
     .expect("transcript");
 
-    let public_bytes = serialize_public_inputs(public_inputs);
+    let public_bytes = serialize_public_inputs(public_inputs).expect("public inputs serialization");
     transcript
         .absorb_public_inputs(&public_bytes)
         .expect("public inputs");

--- a/tests/ser_structures.rs
+++ b/tests/ser_structures.rs
@@ -61,7 +61,8 @@ fn sample_proof() -> Proof {
         header: header.clone(),
         body: &body_bytes,
     };
-    let public_input_bytes = rpp_stark::proof::ser::serialize_public_inputs(&public_inputs);
+    let public_input_bytes = rpp_stark::proof::ser::serialize_public_inputs(&public_inputs)
+        .expect("public inputs serialization");
     let public_digest = rpp_stark::proof::ser::compute_public_digest(&public_input_bytes);
 
     let merkle = MerkleProofBundle {
@@ -133,8 +134,9 @@ fn sample_proof() -> Proof {
         },
     };
 
-    let payload = serialize_proof_payload(&proof);
-    let header_bytes = serialize_proof_header(&proof, &payload);
+    let payload = serialize_proof_payload(&proof).expect("proof payload serialization");
+    let header_bytes =
+        serialize_proof_header(&proof, &payload).expect("proof header serialization");
     let integrity = compute_integrity_digest(&header_bytes, &payload);
     proof.telemetry.header_length = header_bytes.len() as u32;
     proof.telemetry.body_length = (payload.len() + 32) as u32;


### PR DESCRIPTION
## Summary
- make `serialize_public_inputs`, FRI encoding, and proof header/payload writers return `Result` and add explicit length checks
- plumb serialization failures through `ProofBuilder`, prover, verifier, and aggregation helpers with new `ProverError::Serialization`
- update tests and utilities to expect fallible serialization helpers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e6919225108326ac73ea7d8040ccda