### PR TITLE
Handle deterministic hash conversion errors

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -134,9 +134,13 @@ fn build_sample_proof(
     let mut reader = sample_reader(profile.id, run_label);
 
     let mut core_root = [0u8; 32];
-    reader.fill(&mut core_root);
+    reader
+        .fill(&mut core_root)
+        .expect("profile sampler XOF should not fail");
     let mut aux_root = [0u8; 32];
-    reader.fill(&mut aux_root);
+    reader
+        .fill(&mut aux_root)
+        .expect("profile sampler XOF should not fail");
 
     let mut fri_layer_roots = Vec::new();
     for _ in 0..2 {
@@ -253,7 +257,9 @@ fn sample_reader(profile_id: ProfileId, run_label: &str) -> OutputReader {
 
 fn sample_digest(reader: &mut OutputReader) -> [u8; 32] {
     let mut bytes = [0u8; 32];
-    reader.fill(&mut bytes);
+    reader
+        .fill(&mut bytes)
+        .expect("profile sampler XOF should not fail");
     bytes
 }
 
@@ -274,7 +280,9 @@ fn build_trace_stub(fri_proof: &FriProof) -> TraceOpenings {
 
 fn sample_u64(reader: &mut OutputReader) -> u64 {
     let mut bytes = [0u8; 8];
-    reader.fill(&mut bytes);
+    reader
+        .fill(&mut bytes)
+        .expect("profile sampler XOF should not fail");
     u64::from_le_bytes(bytes)
 }
 

--- a/src/fri/prover.rs
+++ b/src/fri/prover.rs
@@ -15,6 +15,7 @@ fn map_transcript_error(err: TranscriptError) -> FriError {
         TranscriptError::Serialization(_) => FriError::InvalidStructure("transcript-ser"),
         TranscriptError::BoundsViolation => FriError::InvalidStructure("transcript-bounds"),
         TranscriptError::Unsupported => FriError::InvalidStructure("transcript-unsupported"),
+        TranscriptError::DeterministicHash(err) => FriError::DeterministicHash(err),
     }
 }
 
@@ -88,7 +89,7 @@ pub fn fri_prove(
     let mut query_seed = [0u8; 32];
     query_seed.copy_from_slice(&query_seed_bytes);
 
-    let positions = derive_query_positions(query_seed, view.query_count(), evaluations.len());
+    let positions = derive_query_positions(query_seed, view.query_count(), evaluations.len())?;
     let mut queries = Vec::with_capacity(positions.len());
 
     for &position in &positions {

--- a/src/fri/types.rs
+++ b/src/fri/types.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use crate::hash::deterministic::DeterministicHashError;
 use crate::hash::merkle::MerkleError;
 use crate::params::StarkParams;
 
@@ -166,6 +167,8 @@ pub enum FriError {
     },
     /// Generic structure error (missing layer, inconsistent lengths, etc.).
     InvalidStructure(&'static str),
+    /// Deterministic hashing helper failed while sampling challenges.
+    DeterministicHash(DeterministicHashError),
 }
 
 impl fmt::Display for FriError {
@@ -200,11 +203,20 @@ impl fmt::Display for FriError {
                 "query budget mismatch (expected {expected}, got {actual})"
             ),
             FriError::InvalidStructure(reason) => write!(f, "invalid proof structure: {reason}"),
+            FriError::DeterministicHash(err) => {
+                write!(f, "deterministic hash error: {err}")
+            }
         }
     }
 }
 
 impl std::error::Error for FriError {}
+
+impl From<DeterministicHashError> for FriError {
+    fn from(err: DeterministicHashError) -> Self {
+        FriError::DeterministicHash(err)
+    }
+}
 
 /// Borrowed view over the parameters required when verifying a proof.
 #[derive(Debug, Clone, Copy)]

--- a/src/fri/verifier.rs
+++ b/src/fri/verifier.rs
@@ -18,6 +18,7 @@ fn map_transcript_error(err: TranscriptError) -> FriError {
         TranscriptError::Serialization(_) => FriError::InvalidStructure("transcript-ser"),
         TranscriptError::BoundsViolation => FriError::InvalidStructure("transcript-bounds"),
         TranscriptError::Unsupported => FriError::InvalidStructure("transcript-unsupported"),
+        TranscriptError::DeterministicHash(err) => FriError::DeterministicHash(err),
     }
 }
 
@@ -113,7 +114,7 @@ pub fn fri_verify(
     let mut query_seed = [0u8; 32];
     query_seed.copy_from_slice(&query_seed_bytes);
 
-    let positions = derive_query_positions(query_seed, query_count, proof.initial_domain_size);
+    let positions = derive_query_positions(query_seed, query_count, proof.initial_domain_size)?;
     if positions.len() != proof.queries.len() {
         return Err(FriError::InvalidStructure("query count mismatch"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,5 +268,8 @@ fn map_verify_error(error: VerifyError) -> StarkError {
             StarkError::InvalidInput("aggregation_digest_mismatch")
         }
         VerifyError::Serialization(_) => StarkError::InvalidInput("serialization_error"),
+        VerifyError::DeterministicHash(_) => {
+            StarkError::SubsystemFailure("deterministic_hash_error")
+        }
     }
 }

--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -1,5 +1,6 @@
 use crate::config::{AirSpecId, ParamDigest, ProofKind};
 use crate::fri::FriProof;
+use crate::hash::deterministic::DeterministicHashError;
 use crate::ser::SerKind;
 use crate::utils::serialization::DigestBytes;
 use serde::{Deserialize, Serialize};
@@ -316,11 +317,19 @@ pub enum VerifyError {
     AggregationDigestMismatch,
     /// Malformed serialization encountered while decoding a proof section.
     Serialization(SerKind),
+    /// Deterministic hashing helper failed while sampling queries.
+    DeterministicHash(DeterministicHashError),
 }
 
 impl From<crate::ser::SerError> for VerifyError {
     fn from(err: crate::ser::SerError) -> Self {
         VerifyError::Serialization(err.kind())
+    }
+}
+
+impl From<DeterministicHashError> for VerifyError {
+    fn from(err: DeterministicHashError) -> Self {
+        VerifyError::DeterministicHash(err)
     }
 }
 

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -507,7 +507,7 @@ fn derive_trace_query_indices(
     let mut indices = Vec::with_capacity(target);
 
     while indices.len() < target {
-        let position = sampler.challenge_usize(domain_size);
+        let position = sampler.challenge_usize(domain_size)?;
         if !seen[position] {
             seen[position] = true;
             indices.push(position as u32);
@@ -558,10 +558,10 @@ impl QueryIndexSampler {
         }
     }
 
-    fn challenge_usize(&mut self, range: usize) -> usize {
+    fn challenge_usize(&mut self, range: usize) -> Result<usize, VerifyError> {
         debug_assert!(range > 0);
-        let word = self.xof.next_u64();
-        (word % (range as u64)) as usize
+        let word = self.xof.next_u64().map_err(VerifyError::from)?;
+        Ok((word % (range as u64)) as usize)
     }
 }
 
@@ -1024,5 +1024,6 @@ fn map_fri_error(error: FriError) -> VerifyError {
         FriError::InvalidStructure(_) => VerifyError::MerkleVerifyFailed {
             section: MerkleSection::FriPath,
         },
+        FriError::DeterministicHash(err) => VerifyError::DeterministicHash(err),
     }
 }

--- a/src/transcript/core.rs
+++ b/src/transcript/core.rs
@@ -331,7 +331,7 @@ impl Transcript {
         seed.extend_from_slice(&label.domain_tag());
         seed.extend_from_slice(&self.challenge_counter.to_le_bytes());
         let mut reader = PseudoBlake3Xof::new(&seed);
-        reader.squeeze(output);
+        reader.squeeze(output).map_err(TranscriptError::from)?;
         self.state = mix(self.state, label, output);
         self.xof = PseudoBlake3Xof::from_state(self.state);
         Ok(())

--- a/src/transcript/types.rs
+++ b/src/transcript/types.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 use crate::field::FieldElement;
+use crate::hash::deterministic::DeterministicHashError;
 
 /// Canonical field element type absorbed by the transcript.
 pub type Felt = FieldElement;
@@ -152,6 +153,8 @@ pub enum TranscriptError {
     BoundsViolation,
     /// Feature not supported by the deterministic transcript.
     Unsupported,
+    /// Deterministic hashing helper failed.
+    DeterministicHash(DeterministicHashError),
 }
 
 impl fmt::Display for TranscriptError {
@@ -165,8 +168,17 @@ impl fmt::Display for TranscriptError {
             TranscriptError::Unsupported => {
                 write!(f, "feature unsupported in deterministic transcript")
             }
+            TranscriptError::DeterministicHash(err) => {
+                write!(f, "deterministic hash error: {err}")
+            }
         }
     }
 }
 
 impl core::error::Error for TranscriptError {}
+
+impl From<DeterministicHashError> for TranscriptError {
+    fn from(err: DeterministicHashError) -> Self {
+        TranscriptError::DeterministicHash(err)
+    }
+}

--- a/src/vrf/mod.rs
+++ b/src/vrf/mod.rs
@@ -9,7 +9,7 @@
 pub mod pq;
 
 use crate::config::TranscriptVersionId;
-use crate::hash::Hash;
+use crate::hash::{deterministic::DeterministicHashError, Hash};
 use crate::proof::public_inputs::ProofKind;
 
 /// Canonical domain separation tag absorbed into the transcript.
@@ -346,6 +346,14 @@ pub enum VrfVerificationFailure {
     ErrVrfLegacyRejected,
     /// PQ-VRF attempted before the cutover point when disallowed.
     ErrVrfCutoverNotReached,
+    /// Deterministic hashing helper failed.
+    ErrDeterministicHash(DeterministicHashError),
+}
+
+impl From<DeterministicHashError> for VrfVerificationFailure {
+    fn from(err: DeterministicHashError) -> Self {
+        VrfVerificationFailure::ErrDeterministicHash(err)
+    }
 }
 
 /// Test plan covering determinism, bias checks and cutover enforcement.

--- a/tests/fri_end_to_end.rs
+++ b/tests/fri_end_to_end.rs
@@ -101,7 +101,7 @@ fn derive_query_positions_from_proof(proof: &FriProof, seed: FriTranscriptSeed) 
     let mut seen = vec![false; proof.initial_domain_size];
 
     while unique.len() < target {
-        let word = xof.next_u64();
+        let word = xof.next_u64().expect("query sampling");
         let position = (word % (proof.initial_domain_size as u64)) as usize;
         if !seen[position] {
             seen[position] = true;

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -449,7 +449,9 @@ fn derive_query_indices(seed: [u8; 32], count: usize, domain_size: usize) -> Vec
     let mut unique = Vec::with_capacity(target);
     let mut seen = vec![false; domain_size];
     while unique.len() < target {
-        let word = xof.next_u64();
+        let word = xof
+            .next_u64()
+            .expect("deterministic query sampling must succeed");
         let position = (word % (domain_size as u64)) as usize;
         if !seen[position] {
             seen[position] = true;


### PR DESCRIPTION
## Summary
- add a serializable `DeterministicHashError` and make the pseudo-BLAKE3 XOF helpers return `Result`
- propagate deterministic hash failures through transcript, FRI, verifier, and VRF error types while updating call sites
- update sample code and tests to handle the fallible API and assert on deterministic expectations

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e6a5592cd08326ab99f27976777222