### PR TITLE
Make field canonical checks fallible

### DIFF
--- a/benches/air_benches.rs
+++ b/benches/air_benches.rs
@@ -68,9 +68,10 @@ fn pack_leaves(values: &[FieldElement], leaf_width: usize) -> Vec<Leaf> {
     values
         .chunks(leaf_width)
         .map(|chunk| {
-            let mut bytes = Vec::with_capacity(leaf_width * FieldElement::ZERO.to_bytes().len());
+            let mut bytes = Vec::with_capacity(leaf_width * FieldElement::BYTE_LENGTH);
             for felt in chunk {
-                bytes.extend_from_slice(&felt.to_bytes());
+                let le = felt.to_bytes().expect("benchmark inputs must be canonical");
+                bytes.extend_from_slice(&le);
             }
             Leaf::new(bytes)
         })
@@ -130,7 +131,9 @@ fn stage_transcript(
         .absorb_digest(
             TranscriptLabel::PublicInputsDigest,
             &DigestBytes {
-                bytes: inputs.digest(),
+                bytes: inputs
+                    .digest()
+                    .expect("fixture public inputs must be canonical"),
             },
         )
         .expect("absorb public inputs");

--- a/benches/fri_benches.rs
+++ b/benches/fri_benches.rs
@@ -96,7 +96,8 @@ fn bench_layer_commitment(c: &mut Criterion) {
         group.throughput(Throughput::Elements(layer.values.len() as u64));
         group.bench_with_input(BenchmarkId::new("commit", label), layer, |b, input| {
             b.iter(|| {
-                let committed = FriLayer::new(input.index, input.coset_shift, input.values.clone());
+                let committed = FriLayer::new(input.index, input.coset_shift, input.values.clone())
+                    .expect("layer commitment");
                 black_box(committed.root());
             });
         });

--- a/src/air/composition.rs
+++ b/src/air/composition.rs
@@ -217,12 +217,15 @@ fn evaluations_to_leaves(evaluations: &[Felt], leaf_width: usize) -> Result<Vec<
         ));
     }
 
-    let element_bytes = Felt::ZERO.to_bytes();
     let mut leaves = Vec::with_capacity(evaluations.len() / leaf_width);
     for chunk in evaluations.chunks(leaf_width) {
-        let mut bytes = Vec::with_capacity(leaf_width * element_bytes.len());
+        let mut bytes = Vec::with_capacity(leaf_width * Felt::BYTE_LENGTH);
         for felt in chunk {
-            bytes.extend_from_slice(&felt.to_bytes());
+            let encoded = felt.to_bytes().map_err(|_| AirError::Serialization {
+                kind: SerKind::Trace,
+                detail: "non-canonical constraint evaluation",
+            })?;
+            bytes.extend_from_slice(&encoded);
         }
         leaves.push(Leaf::new(bytes));
     }

--- a/src/air/trace.rs
+++ b/src/air/trace.rs
@@ -425,7 +425,15 @@ mod tests {
             Felt::from(6u64),
         ];
         assert_eq!(trace.as_slice(), expected.as_slice());
-        let serialized: Vec<[u8; 8]> = trace.as_slice().iter().map(Felt::to_bytes).collect();
+        let serialized: Vec<[u8; 8]> = trace
+            .as_slice()
+            .iter()
+            .map(|value| {
+                value
+                    .to_bytes()
+                    .expect("trace fixture values must be canonical")
+            })
+            .collect();
         assert_eq!(serialized[0], 1u64.to_le_bytes());
         assert_eq!(serialized[3], 4u64.to_le_bytes());
         Ok(())

--- a/src/air/traits.rs
+++ b/src/air/traits.rs
@@ -225,7 +225,9 @@ mod tests {
 
         fn encode(&self, value: &Self::Value) -> Result<Vec<FieldElementBytes>, AirError> {
             let mut buf = [0u8; 32];
-            let le = value.to_bytes();
+            let le = value
+                .to_bytes()
+                .expect("mock codec should receive canonical values");
             buf[..le.len()].copy_from_slice(&le);
             Ok(vec![FieldElementBytes { bytes: buf }])
         }

--- a/src/air/types.rs
+++ b/src/air/types.rs
@@ -377,7 +377,10 @@ impl TraceData {
         let mut bytes = Vec::with_capacity(column.len());
         for value in column {
             let mut buf = [0u8; 32];
-            let le = value.to_bytes();
+            let le = value.to_bytes().map_err(|_| AirError::Serialization {
+                kind: SerKind::Trace,
+                detail: "non-canonical trace value",
+            })?;
             buf[..le.len()].copy_from_slice(&le);
             bytes.push(FieldElementBytes { bytes: buf });
         }

--- a/src/field/tests.rs
+++ b/src/field/tests.rs
@@ -24,7 +24,9 @@ fn add_mul_inv_laws_ok() {
 #[test]
 fn serde_le_roundtrip_ok() {
     let element = FieldElement::from(42u64);
-    let bytes = element.to_bytes();
+    let bytes = element
+        .to_bytes()
+        .expect("canonical element should serialize");
     let decoded = FieldElement::from_bytes(&bytes).expect("canonical roundtrip");
     assert_eq!(decoded, element);
 }

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -109,6 +109,7 @@ pub use types::{
 };
 pub use verifier::fri_verify;
 
+use crate::field::prime_field::{CanonicalSerialize, FieldConstraintError};
 use crate::field::FieldElement;
 use crate::hash::hash;
 
@@ -183,17 +184,17 @@ pub(crate) fn field_from_hash(bytes: &[u8; 32]) -> FieldElement {
 
 /// Helper converting a field element into canonical little-endian bytes.
 #[inline]
-pub(crate) fn field_to_bytes(value: &FieldElement) -> [u8; 8] {
-    value.0.to_le_bytes()
+pub(crate) fn field_to_bytes(value: &FieldElement) -> Result<[u8; 8], FieldConstraintError> {
+    value.to_bytes()
 }
 
 /// Hashes a field element into a leaf digest using the canonical leaf framing.
 #[inline]
-pub(crate) fn hash_leaf(value: &FieldElement) -> [u8; 32] {
+pub(crate) fn hash_leaf(value: &FieldElement) -> Result<[u8; 32], FieldConstraintError> {
     let mut payload = Vec::with_capacity(12);
     payload.extend_from_slice(&(8u32.to_le_bytes()));
-    payload.extend_from_slice(&field_to_bytes(value));
-    hash(&payload).into()
+    payload.extend_from_slice(&field_to_bytes(value)?);
+    Ok(hash(&payload).into())
 }
 
 /// Hashes two child digests into their parent digest.

--- a/src/fri/prover.rs
+++ b/src/fri/prover.rs
@@ -58,7 +58,7 @@ pub fn fri_prove(
             return Err(FriError::InvalidStructure("layer-index-overflow"));
         }
 
-        let layer = FriLayer::new(layer_index, coset_shift, current);
+        let layer = FriLayer::new(layer_index, coset_shift, current)?;
         let root = layer.root();
         transcript
             .absorb_digest(
@@ -77,7 +77,7 @@ pub fn fri_prove(
     }
 
     let final_polynomial = current;
-    let final_polynomial_digest = hash_final_layer(&final_polynomial);
+    let final_polynomial_digest = hash_final_layer(&final_polynomial)?;
 
     let count_bytes = (view.query_count() as u32).to_le_bytes();
     transcript

--- a/src/fri/types.rs
+++ b/src/fri/types.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use crate::field::prime_field::FieldConstraintError;
 use crate::hash::deterministic::DeterministicHashError;
 use crate::hash::merkle::MerkleError;
 use crate::params::StarkParams;
@@ -169,6 +170,8 @@ pub enum FriError {
     InvalidStructure(&'static str),
     /// Deterministic hashing helper failed while sampling challenges.
     DeterministicHash(DeterministicHashError),
+    /// Field element violated canonical encoding constraints.
+    FieldConstraint(FieldConstraintError),
 }
 
 impl fmt::Display for FriError {
@@ -206,6 +209,9 @@ impl fmt::Display for FriError {
             FriError::DeterministicHash(err) => {
                 write!(f, "deterministic hash error: {err}")
             }
+            FriError::FieldConstraint(err) => {
+                write!(f, "field constraint violation: {err}")
+            }
         }
     }
 }
@@ -215,6 +221,12 @@ impl std::error::Error for FriError {}
 impl From<DeterministicHashError> for FriError {
     fn from(err: DeterministicHashError) -> Self {
         FriError::DeterministicHash(err)
+    }
+}
+
+impl From<FieldConstraintError> for FriError {
+    fn from(err: FieldConstraintError) -> Self {
+        FriError::FieldConstraint(err)
     }
 }
 

--- a/src/fri/verifier.rs
+++ b/src/fri/verifier.rs
@@ -74,7 +74,7 @@ pub fn fri_verify(
         return Err(FriError::InvalidStructure("final-polynomial-length"));
     }
 
-    let recomputed_digest = hash_final_layer(&proof.final_polynomial);
+    let recomputed_digest = hash_final_layer(&proof.final_polynomial)?;
     if recomputed_digest != proof.final_polynomial_digest {
         return Err(FriError::LayerRootMismatch { layer: num_layers });
     }
@@ -173,7 +173,7 @@ pub fn fri_verify(
                                     layer: layer_index,
                                 });
                             }
-                        } else if hash_leaf(&sibling_value) != sibling_digest {
+                        } else if hash_leaf(&sibling_value)? != sibling_digest {
                             return Err(FriError::FoldingConstraintViolated { layer: layer_index });
                         }
                     }
@@ -186,7 +186,7 @@ pub fn fri_verify(
                         if left_value != FieldElement::ZERO {
                             return Err(FriError::FoldingConstraintViolated { layer: layer_index });
                         }
-                    } else if hash_leaf(&left_value) != sibling_digest {
+                    } else if hash_leaf(&left_value)? != sibling_digest {
                         return Err(FriError::FoldingConstraintViolated { layer: layer_index });
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ fn map_prover_error(error: prover::ProverError) -> StarkError {
         ProverError::Serialization(kind) => {
             map_serialization_error(SerError::invalid_value(kind, "prover_serialization"))
         }
+        ProverError::FieldConstraint(context, _) => StarkError::InvalidInput(context),
     }
 }
 

--- a/src/proof/api.rs
+++ b/src/proof/api.rs
@@ -201,5 +201,8 @@ fn map_prover_error_to_verify(error: prover::ProverError) -> VerifyError {
         },
         ProverError::ProofTooLarge { .. } => VerifyError::ProofTooLarge,
         ProverError::Serialization(kind) => VerifyError::Serialization(kind),
+        ProverError::FieldConstraint(context, _) => {
+            VerifyError::UnexpectedEndOfBuffer(context.to_string())
+        }
     }
 }

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -329,14 +329,15 @@ mod tests {
         bytes.extend_from_slice(&0u32.to_le_bytes());
         bytes.extend_from_slice(&0u32.to_le_bytes());
         for value in column {
-            bytes.extend_from_slice(&value.to_bytes());
+            let encoded = value.to_bytes().expect("fixture values must be canonical");
+            bytes.extend_from_slice(&encoded);
         }
         bytes
     }
 
     fn sample_public_inputs() -> Vec<u8> {
         let seed = FieldElement::from(11u64);
-        let body_bytes = seed.to_bytes();
+        let body_bytes = seed.to_bytes().expect("fixture seed must be canonical");
         let header = ExecutionHeaderV1 {
             version: PublicInputVersion::V1,
             program_digest: DigestBytes { bytes: [2u8; 32] },
@@ -609,7 +610,7 @@ mod tests {
         );
 
         let seed = FieldElement::from(13u64);
-        let seed_bytes = seed.to_bytes();
+        let seed_bytes = seed.to_bytes().expect("fixture seed must be canonical");
         let public_inputs = PublicInputs::Execution {
             header: ExecutionHeaderV1 {
                 version: PublicInputVersion::V1,

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -620,7 +620,7 @@ fn verify_merkle_section(
         return Err(VerifyError::UnsupportedMerkleScheme);
     }
 
-    let element_size = FieldElement::ZERO.to_bytes().len();
+    let element_size = FieldElement::BYTE_LENGTH;
     let expected_leaf_bytes = element_size * params.merkle().leaf_width as usize;
     let arity = params.merkle().arity;
     let root_digest = MerkleDigest::new(root.to_vec());
@@ -1025,5 +1025,8 @@ fn map_fri_error(error: FriError) -> VerifyError {
             section: MerkleSection::FriPath,
         },
         FriError::DeterministicHash(err) => VerifyError::DeterministicHash(err),
+        FriError::FieldConstraint(_) => VerifyError::FriVerifyFailed {
+            issue: FriVerifyIssue::Generic,
+        },
     }
 }

--- a/src/transcript/core.rs
+++ b/src/transcript/core.rs
@@ -1,6 +1,7 @@
 use crate::hash::deterministic::{pseudo_blake3, Hasher, PseudoBlake3Xof};
 use crate::params::{ChallengeBounds, StarkParams};
 use crate::utils::serialization::DigestBytes;
+use core::convert::TryFrom;
 
 use super::ser;
 use super::types::{
@@ -407,7 +408,7 @@ impl Transcript {
 }
 
 fn encode_felt(felt: Felt) -> Result<[u8; 32], ()> {
-    let value: u64 = felt.into();
+    let value = u64::try_from(felt).map_err(|_| ())?;
     let mut out = [0u8; 32];
     out[..8].copy_from_slice(&value.to_le_bytes());
     Ok(out)

--- a/tests/air_end_to_end.rs
+++ b/tests/air_end_to_end.rs
@@ -122,7 +122,10 @@ fn fri_pipeline_rejects_trace_root_tampering() {
         .absorb_digest(
             TranscriptLabel::PublicInputsDigest,
             &DigestBytes {
-                bytes: fixture.inputs.digest(),
+                bytes: fixture
+                    .inputs
+                    .digest()
+                    .expect("fixture inputs must be canonical"),
             },
         )
         .expect("absorb public inputs");
@@ -199,7 +202,7 @@ fn build_fixture() -> LfsrFriFixture {
         .absorb_digest(
             TranscriptLabel::PublicInputsDigest,
             &DigestBytes {
-                bytes: inputs.digest(),
+                bytes: inputs.digest().expect("fixture inputs must be canonical"),
             },
         )
         .expect("absorb public inputs");
@@ -284,9 +287,10 @@ fn pack_leaves(values: &[FieldElement], leaf_width: usize) -> Vec<Leaf> {
     values
         .chunks(leaf_width)
         .map(|chunk| {
-            let mut bytes = Vec::with_capacity(leaf_width * FieldElement::ZERO.to_bytes().len());
+            let mut bytes = Vec::with_capacity(leaf_width * FieldElement::BYTE_LENGTH);
             for felt in chunk {
-                bytes.extend_from_slice(&felt.to_bytes());
+                let le = felt.to_bytes().expect("fixture values are canonical");
+                bytes.extend_from_slice(&le);
             }
             Leaf::new(bytes)
         })
@@ -299,7 +303,10 @@ fn prepare_verifier_transcript(fixture: &LfsrFriFixture) -> Transcript {
         .absorb_digest(
             TranscriptLabel::PublicInputsDigest,
             &DigestBytes {
-                bytes: fixture.inputs.digest(),
+                bytes: fixture
+                    .inputs
+                    .digest()
+                    .expect("fixture inputs must be canonical"),
             },
         )
         .expect("absorb public inputs");

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -232,7 +232,9 @@ fn build_envelope(
 
     let params = canonical_stark_params(&context.profile);
     let leaf_count = initial_domain_size.max(1);
-    let zero_leaf = FieldElement::ZERO.to_bytes();
+    let zero_leaf = FieldElement::ZERO
+        .to_bytes()
+        .expect("zero is a canonical field element");
     let trace_leaves: Vec<Leaf> = (0..leaf_count)
         .map(|_| Leaf::new(zero_leaf.to_vec()))
         .collect();
@@ -504,7 +506,7 @@ fn hash_final_layer(values: &[FieldElement]) -> [u8; 32] {
     let mut payload = Vec::with_capacity(4 + values.len() * 8);
     payload.extend_from_slice(&(values.len() as u32).to_le_bytes());
     for value in values {
-        let bytes = value.to_bytes();
+        let bytes = value.to_bytes().expect("synthetic values are canonical");
         payload.extend_from_slice(&bytes);
     }
     pseudo_blake3(&payload)
@@ -524,7 +526,12 @@ fn build_opening_artifacts(
         let bytes = leaves
             .get(index as usize)
             .map(|leaf| leaf.as_bytes().to_vec())
-            .unwrap_or_else(|| FieldElement::ZERO.to_bytes().to_vec());
+            .unwrap_or_else(|| {
+                FieldElement::ZERO
+                    .to_bytes()
+                    .expect("zero is canonical")
+                    .to_vec()
+            });
         leaf_bytes.push(bytes);
         paths.push(convert_tree_proof(&proof, index));
     }
@@ -580,7 +587,7 @@ fn convert_tree_proof(proof: &MerkleProof, index: u32) -> MerkleAuthenticationPa
 
 fn field_to_bytes(value: FieldElement) -> [u8; 32] {
     let mut bytes = [0u8; 32];
-    let le = value.to_bytes();
+    let le = value.to_bytes().expect("test values should be canonical");
     bytes[..le.len()].copy_from_slice(&le);
     bytes
 }

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -52,7 +52,10 @@ impl TestSetup {
             trace_length: length as u32,
             trace_width: 1,
         };
-        let body = seed.to_bytes().to_vec();
+        let body = seed
+            .to_bytes()
+            .expect("fixture seed must be canonical")
+            .to_vec();
         let witness = build_witness(seed, length);
 
         Self {
@@ -87,7 +90,8 @@ fn build_witness(seed: FieldElement, rows: usize) -> Vec<u8> {
     bytes.extend_from_slice(&0u32.to_le_bytes());
     bytes.extend_from_slice(&0u32.to_le_bytes());
     for value in column {
-        bytes.extend_from_slice(&value.to_bytes());
+        let encoded = value.to_bytes().expect("fixture values must be canonical");
+        bytes.extend_from_slice(&encoded);
     }
     bytes
 }

--- a/tests/proof_merkle_quaternary.rs
+++ b/tests/proof_merkle_quaternary.rs
@@ -49,7 +49,10 @@ fn build_setup() -> (
         trace_length: length as u32,
         trace_width: 1,
     };
-    let body = seed.to_bytes().to_vec();
+    let body = seed
+        .to_bytes()
+        .expect("fixture seed must be canonical")
+        .to_vec();
     let witness = build_witness(seed, length);
 
     (
@@ -80,7 +83,8 @@ fn build_witness(seed: FieldElement, rows: usize) -> Vec<u8> {
     bytes.extend_from_slice(&0u32.to_le_bytes());
     bytes.extend_from_slice(&0u32.to_le_bytes());
     for value in column {
-        bytes.extend_from_slice(&value.to_bytes());
+        let encoded = value.to_bytes().expect("fixture values must be canonical");
+        bytes.extend_from_slice(&encoded);
     }
     bytes
 }

--- a/tests/transcript_determinism.rs
+++ b/tests/transcript_determinism.rs
@@ -94,12 +94,17 @@ fn deterministic_state_digest() {
     let close2 = t2.challenge_bytes(TranscriptLabel::ProofClose, 32).unwrap();
     assert_eq!(close1, close2);
     let proof_close_hex: String = close1.iter().map(|b| format!("{:02x}", b)).collect();
-    let fri_fold_scalars: Vec<u64> = fri_folds.iter().map(|f| u64::from(*f)).collect();
+    let fri_fold_scalars: Vec<u64> = fri_folds
+        .iter()
+        .map(|f| u64::try_from(*f).expect("canonical fold scalar"))
+        .collect();
     assert_json_snapshot!(
         "transcript_profile_x8",
         serde_json::json!({
-            "trace_challenge": u64::from(trace_challenge_a1),
-            "comp_challenge": u64::from(comp_challenge_a1),
+            "trace_challenge": u64::try_from(trace_challenge_a1)
+                .expect("canonical trace challenge"),
+            "comp_challenge": u64::try_from(comp_challenge_a1)
+                .expect("canonical composition challenge"),
             "fri_folds": fri_fold_scalars,
             "query_indices": idxs1,
             "proof_close_hex": proof_close_hex,


### PR DESCRIPTION
## Summary
- introduce a `FieldConstraintError` and make the constant-time assertions plus canonical serialization return `Result`
- propagate canonicality failures through the AIR/FRI/proof stack and map them into existing error types
- update transcripts, benches, and tests to handle the new fallible conversions

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e6a94f6d448326a38d07c64429e550