### PR TITLE
Validate header roots before verifying Merkle sections

### DIFF
--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -253,12 +253,6 @@ fn precheck_body(
     block_context: Option<&TranscriptBlockContext>,
     stages: &mut VerificationStages,
 ) -> Result<PrecheckedBody, VerifyError> {
-    if proof.merkle.fri_layer_roots != proof.fri_proof.layer_roots {
-        return Err(VerifyError::MerkleVerifyFailed {
-            section: MerkleSection::FriRoots,
-        });
-    }
-
     if proof.trace_commit.bytes != proof.merkle.core_root {
         return Err(VerifyError::RootMismatch {
             section: MerkleSection::TraceCommit,
@@ -293,6 +287,12 @@ fn precheck_body(
                 });
             }
         }
+    }
+
+    if proof.merkle.fri_layer_roots != proof.fri_proof.layer_roots {
+        return Err(VerifyError::MerkleVerifyFailed {
+            section: MerkleSection::FriRoots,
+        });
     }
 
     stages.merkle_ok = true;
@@ -367,7 +367,7 @@ fn precheck_body(
 
     let trace_values = verify_trace_commitment(
         &stark_params,
-        &proof.merkle.core_root,
+        &proof.trace_commit.bytes,
         &proof.openings.trace,
     )?;
 


### PR DESCRIPTION
## Summary
- ensure precheck_body compares header and body roots before proceeding and rely on header commitments when checking Merkle openings
- add helpers to mutate header roots in tests and cover tampered trace and composition headers raising root mismatch errors

## Testing
- cargo test --test proof_lifecycle

------
https://chatgpt.com/codex/tasks/task_e_68e6b970ea308326b7d66afb83df6849