### PR TITLE
Add blueprint baseline requirements for STWO compatibility

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1,0 +1,32 @@
+# Blueprint für eine STWO-kompatible STARK-Library (stable-only)
+
+## 0) Basisanforderungen (global, für das gesamte Projekt)
+
+### Toolchain / MSRV
+
+- Rust stable; empfohlene MSRV: 1.79.
+- MSRV im Projekt fest dokumentiert (Manifeste, README, CI).
+
+### Safety & Stil
+
+- Kein unsafe.
+- Keine Panics in Bibliothekslogik, keine impliziten Abbrüche; harte Fehler nur über definierte Fehler-Enums.
+- Lint-Gate: Clippy ohne Warnungen.
+
+### Determinismus
+
+- Identische Inputs ⇒ bitidentische Outputs (Proof-Bytes, Roots, Indizes, Challenges).
+- Keine OS-RNGs, keine Uhrzeiten; alle Pseudozufälle ausschließlich über Transcript.
+
+### Reproduzierbarkeit
+
+- Snapshots für Byte-Artefakte (Proof, Params, FRI-Roots, Query-Listen).
+- Build/Tests deterministisch (keine Umgebungsabhängigkeiten).
+
+### Dokumentation
+
+- Zentrale Spezifikationsdokumente: siehe Abschnitt 12.
+
+### Audit-Check (0)
+
+- _[Dieser Abschnitt ist als Platzhalter für konkrete Audit-Aufgaben reserviert.]_


### PR DESCRIPTION
## Summary
- document baseline toolchain, safety, and determinism requirements for the STWO-compatible STARK library
- capture reproducibility, documentation, and audit placeholder guidance in a dedicated blueprint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6c79049a083269e8894650c5dc679