### PR TITLE
Add fail matrix fixture and mutation helpers

### DIFF
--- a/tests/fail_matrix/mod.rs
+++ b/tests/fail_matrix/mod.rs
@@ -1,0 +1,6 @@
+mod fixture;
+
+pub use fixture::{
+    corrupt_merkle_path, flip_header_version, flip_param_digest_byte, swap_trace_indices,
+    FailMatrixFixture,
+};

--- a/tests/proof_artifacts.rs
+++ b/tests/proof_artifacts.rs
@@ -1,5 +1,4 @@
 use insta::assert_json_snapshot;
-use std::collections::BTreeMap;
 use rpp_stark::config::{
     build_proof_system_config, build_prover_context, compute_param_digest, ChunkingPolicy,
     CommonIdentifiers, ProfileConfig, ProofSystemConfig, ProverContext, ThreadPoolProfile,
@@ -11,6 +10,7 @@ use rpp_stark::proof::public_inputs::{
     ExecutionHeaderV1, ProofKind, PublicInputVersion, PublicInputs,
 };
 use rpp_stark::utils::serialization::{ProofBytes, WitnessBlob};
+use std::collections::BTreeMap;
 
 fn hex<const N: usize>(bytes: &[u8; N]) -> String {
     bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
@@ -139,15 +139,11 @@ fn snapshot_execution_proof_artifacts() {
         indices.sort_unstable();
         indices
     };
-    let composition_indices = decoded
-        .openings
-        .composition
-        .as_ref()
-        .map(|comp| {
-            let mut indices = comp.indices.clone();
-            indices.sort_unstable();
-            indices
-        });
+    let composition_indices = decoded.openings.composition.as_ref().map(|comp| {
+        let mut indices = comp.indices.clone();
+        indices.sort_unstable();
+        indices
+    });
     let fri_positions: Vec<usize> = decoded
         .fri_proof
         .queries

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -440,7 +440,8 @@ fn proof_decode_rejects_public_digest_tampering() {
     .expect("proof generation succeeds");
 
     let mutated = mutate_public_digest(&proof_bytes);
-    let decode_error = rpp_stark::Proof::from_bytes(mutated.as_slice()).expect_err("decode must fail");
+    let decode_error =
+        rpp_stark::Proof::from_bytes(mutated.as_slice()).expect_err("decode must fail");
     assert!(matches!(decode_error, VerifyError::PublicDigestMismatch));
 
     let declared_kind = map_public_to_config_kind(ProofKind::Execution);


### PR DESCRIPTION
## Summary
- add a reusable FailMatrixFixture that clones the standard profile and tunes it for a mini proof setup
- provide helper functions to mutate specific portions of the proof and reserialize the bytes
- apply formatting updates from running cargo fmt in existing tests

## Testing
- cargo test fail_matrix -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e6cc4053208326aad323726a107a60