### PR TITLE
Add helper to flip composition leaf byte

### DIFF
--- a/tests/fail_matrix.rs
+++ b/tests/fail_matrix.rs
@@ -10,8 +10,9 @@ mod merkle;
 mod fri;
 
 pub use fixture::{
-    corrupt_merkle_path, duplicate_composition_index, duplicate_trace_index, flip_header_version,
-    flip_param_digest_byte, flip_public_digest_byte, mismatch_composition_indices,
-    mismatch_trace_indices, mismatch_trace_root, perturb_fri_fold_challenge, swap_composition_indices,
-    swap_trace_indices, truncate_trace_paths, FailMatrixFixture, MutatedProof,
+    corrupt_merkle_path, duplicate_composition_index, duplicate_trace_index,
+    flip_composition_leaf_byte, flip_header_version, flip_param_digest_byte,
+    flip_public_digest_byte, mismatch_composition_indices, mismatch_trace_indices,
+    mismatch_trace_root, perturb_fri_fold_challenge, swap_composition_indices, swap_trace_indices,
+    truncate_trace_paths, FailMatrixFixture, MutatedProof,
 };

--- a/tests/fail_matrix/fixture.rs
+++ b/tests/fail_matrix/fixture.rs
@@ -290,6 +290,29 @@ where
     }
 }
 
+/// Flips the first byte of the leading composition opening leaf (if present).
+pub fn flip_composition_leaf_byte(proof: &Proof) -> Option<MutatedProof> {
+    let Some(composition) = proof.openings.composition.as_ref() else {
+        return None;
+    };
+    let Some(leaf) = composition.leaves.first() else {
+        return None;
+    };
+    if leaf.is_empty() {
+        return None;
+    }
+
+    Some(mutate_proof(proof, |proof| {
+        if let Some(composition) = proof.openings.composition.as_mut() {
+            if let Some(leaf) = composition.leaves.first_mut() {
+                if let Some(byte) = leaf.first_mut() {
+                    *byte ^= 0x01;
+                }
+            }
+        }
+    }))
+}
+
 /// Swaps the first two trace query indices.
 pub fn swap_trace_indices(proof: &Proof) -> MutatedProof {
     mutate_trace_indices_with(proof, |indices| {


### PR DESCRIPTION
## Summary
- add a helper that mutates the first byte of the leading composition opening leaf when present
- re-export the helper so other fail matrix modules can use it

## Testing
- cargo fmt


------
https://chatgpt.com/codex/tasks/task_e_68e6e3c12c0c832692a7879da82fbbcc