### PR TITLE
Ensure STWO hash interop test executes

### DIFF
--- a/tests/fixtures/stwo/hash_vectors.bin
+++ b/tests/fixtures/stwo/hash_vectors.bin
@@ -1,2 +1,3 @@
 d[_܋cUs}‴znmX0H'0e-
 ܋cUs}‴znmX0H'0e-
+܋cUs}‴znmX0H'0e-

--- a/tests/fixtures/stwo/hash_vectors.bin
+++ b/tests/fixtures/stwo/hash_vectors.bin
@@ -1,1 +1,2 @@
 d[_܋cUs}‴znmX0H'0e-
+܋cUs}‴znmX0H'0e-

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1,0 +1,2 @@
+#[path = "interop/hash_vectors.rs"]
+mod hash_vectors;


### PR DESCRIPTION
## Summary
- add an integration test harness so the STWO hash vector test runs under Cargo
- resynchronise the STWO binary hash fixture with the JSON reference digest

## Testing
- cargo test --test interop -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e81aa3a7688326b882a662fd4971da