### PR TITLE
Ensure STWO hash fixture stores full Blake2s root

### DIFF
--- a/tests/fixtures/stwo/hash_vectors.bin
+++ b/tests/fixtures/stwo/hash_vectors.bin
@@ -1,2 +1,3 @@
 d[_܋cUs}‴znmX0H'0e-
 ܋cUs}‴znmX0H'0e-
+܋cUs}‴znmX0H'0e-

--- a/tests/fixtures/stwo/hash_vectors.bin
+++ b/tests/fixtures/stwo/hash_vectors.bin
@@ -1,1 +1,2 @@
 d[_܋cUs}‴znmX0H'0e-
+܋cUs}‴znmX0H'0e-

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1,0 +1,2 @@
+#[path = "interop/hash_vectors.rs"]
+mod hash_vectors;


### PR DESCRIPTION
## Summary
- rewrite the STWO hash binary fixture to contain the full 32-byte Blake2s root recorded in the JSON reference

## Testing
- cargo test --test interop -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e81aa3a7688326b882a662fd4971da