### PR TITLE
Enable deterministic profile snapshot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: cargo clippy --locked -- -D warnings
       - name: Cargo test
         run: cargo test -p rpp-stark -- --nocapture
+      - name: Cargo test snapshot profiles
+        run: cargo test snapshot_profiles -- --exact
       - name: Generate profile reports
         env:
           ENABLE_PROFILE_THR: "1"

--- a/README.md
+++ b/README.md
@@ -172,10 +172,17 @@ The GitHub Actions workflow enforces the following gates:
 
 * `cargo build --locked`
 * `cargo test -p rpp-stark -- --nocapture`
+* `cargo test snapshot_profiles -- --exact`
 * `cargo clippy --locked -- -D warnings`
 * `cargo run --bin profile_reports -- --output reports --include-throughput`
 
 Pull requests must pass all of these checks before merging.
+
+> **Hinweis:** Jede Änderung an den eingebauten STARK-Profilen oder deren
+> Serialisierung erfordert eine Aktualisierung der gefrorenen `insta`-Snapshots
+> unter `tests/snapshots/params_roundtrip__*.snap`. Führe dazu lokal
+> `cargo test snapshot_profiles -- --exact` (oder `cargo insta review`) aus und
+> nimm die neuen Artefakte mit in den Commit auf.
 
 ## Projekt-Blueprint
 

--- a/tests/params_roundtrip.rs
+++ b/tests/params_roundtrip.rs
@@ -167,7 +167,6 @@ proptest! {
 }
 
 #[test]
-#[ignore]
 fn snapshot_profiles() {
     let profile_x8 = StarkParamsBuilder::new().build().unwrap();
     let hisec = StarkParamsBuilder::from_profile(BuiltinProfile::PROFILE_HISEC_X16)

--- a/tests/snapshots/params_roundtrip__profile_hisec_hash.snap
+++ b/tests/snapshots/params_roundtrip__profile_hisec_hash.snap
@@ -2,4 +2,4 @@
 source: tests/params_roundtrip.rs
 expression: "format!(\"{:02x?}\", hisec.params_hash())"
 ---
-[81, 8a, 34, 34, e2, 6d, ce, 94, dd, b8, 13, a9, 5c, 79, 45, 21, 4f, ba, 13, 78, 80, 3f, 45, 00, 30, 25, 1f, 6a, 32, 9e, 46, 03]
+[cd, 51, c9, 00, eb, e0, 56, b1, dc, 22, 27, 3c, e2, 46, a3, 59, f8, 50, 9b, 7e, e3, 6e, 42, 39, 51, 4a, 8a, ac, b0, 26, 4b, a2]

--- a/tests/snapshots/params_roundtrip__profile_x8_hash.snap
+++ b/tests/snapshots/params_roundtrip__profile_x8_hash.snap
@@ -2,4 +2,4 @@
 source: tests/params_roundtrip.rs
 expression: "format!(\"{:02x?}\", profile_x8.params_hash())"
 ---
-[e1, 9d, bd, 0f, c6, 81, 16, 92, d3, b9, 26, cd, 38, e0, 37, 0f, 91, 6d, 70, 50, 5c, 32, 3d, 80, 96, db, 57, 57, 7a, e6, 16, a8]
+[68, fa, 4d, 06, dc, e5, ac, 8f, 0c, 02, 74, d4, 03, a5, ec, de, b8, da, a6, e2, 77, 53, d5, bb, 1a, 09, b4, dd, 3c, de, 0e, 2b]


### PR DESCRIPTION
## Summary
- enable the `snapshot_profiles` integration test and refresh the frozen hashes
- extend the CI workflow with a dedicated snapshot test run and document the policy in the README

## Testing
- cargo test snapshot_profiles
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e8c81beff48326a889472f544837bb