### PR TITLE
Add changelog policy and CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Verify changelog scaffold
+        run: |
+          test -f CHANGELOG.md
+          grep -q '^## \[Unreleased\]' CHANGELOG.md
       - name: Cargo build
         run: cargo build --locked
       - name: Cargo clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to `rpp-stark` are documented in this file. The structure follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the crate adheres to Semantic Versioning. Proof serialization stability is tracked separately via the `PROOF_VERSION` constant.
+
+## Versioning policy
+
+### Proof ABI (`PROOF_VERSION`)
+
+- Bump `PROOF_VERSION` whenever any byte-level aspect of the proof ABI changes (envelope header, openings, transcript labels, Merkle bundle encoding, telemetry).
+- Mirror the new value in every module that re-exports the constant (e.g. `src/proof/types.rs`, `src/merkle/proof.rs`, `src/config/mod.rs`) so verifiers and tooling agree on the proof layout.
+- Regenerate and inspect the deterministic fixtures after the bump; include the snapshot diffs and a CHANGELOG entry that summarises the ABI impact.
+
+### Snapshot maintenance
+
+- `tests/snapshots/proof_artifacts__execution_proof_artifacts.snap` is the canonical fixture for the proof envelope and Merkle bundle layout.
+- Regenerate snapshots after intentional ABI changes by running `cargo test -p rpp-stark -- --nocapture` followed by `cargo insta review` and commit the approved diffs.
+- If snapshots change without bumping `PROOF_VERSION`, halt the review and decide whether the change is a bug or requires an ABI bump.
+
+## [Unreleased]
+
+### ABI
+
+- Proof envelope, transcript, and Merkle bundle serialization are frozen at `PROOF_VERSION = 1`; deterministic snapshots gate regressions in `tests/snapshots/proof_artifacts__execution_proof_artifacts.snap`.
+
+### Changed
+
+- Raised the minimum supported Rust version (MSRV) and CI toolchain to 1.79 to align with deterministic builds (see `RELEASE_NOTES.md`).
+
+### Known gaps / follow-up
+
+- Parameter snapshot guard ("Param-Snapshot-Gate") is still manual; introduce a CI job that rejects changes to parameter digests without a documented justification.
+- Re-evaluate the MSRV 1.79 bump for downstream consumers before tagging the next release; include compatibility notes once a release candidate is prepared.

--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ nightly-Abhängigkeiten.
 - Size-Gate misst echte Serialisierung?
 - Fehler präzise (richtige Variante)?
 - Snapshot-Diffs erklärbar (und ggf. `PROOF_VERSION` erhöht)?
+- `CHANGELOG.md` aktualisiert (Unreleased-Eintrag, PROOF_VERSION-/Snapshot-Hinweis)?
 - Clippy clean, keine `unwrap`/`expect`, kein `unsafe`?
 
 **Risiken & Gegenmaßnahmen**
@@ -920,9 +921,15 @@ nightly-Abhängigkeiten.
 - Negative Property-Tests (gezielte Fail-Injection).
 - README/Docs: Layout-Tabellen (Proof/Openings/Bundle), Label-Reihenfolge, Versionierungspolitik, Size-Gates, STWO-Adapterhinweise.
 - Benchmarks (stable): Parse/Verify für kleine/mittlere Größen; Artefakte speichern.
-- Version taggen; CHANGELOG.
+- Version taggen; [`CHANGELOG.md`](CHANGELOG.md) mit Release-Abschnitt und PROOF-ABI-Hinweisen aktualisieren.
 
 **DoD:** Doku vollständig, CI grün, Bench-Artefakte vorhanden, Tag v1.0.0.
+
+#### CHANGELOG- & Proof-ABI-Pflege
+
+- Jede Änderung am Serialisierungs-Layout des Proofs (Envelope, Openings, Transcript, Merkle-Bundles, Telemetry) erfordert einen `PROOF_VERSION`-Bump und einen dokumentierten Eintrag im [`CHANGELOG.md`](CHANGELOG.md).
+- Snapshots werden nach ABI-Änderungen via `cargo test -p rpp-stark -- --nocapture` ausgeführt und anschließend mit `cargo insta review` geprüft; nur genehmigte Diffs landen im Repo.
+- Vor dem Merge prüft das Review-Team, ob `CHANGELOG.md` gepflegt wurde (Unreleased-Eintrag, PROOF_VERSION-Notiz) und ob der Snapshot-Diff mit der dokumentierten Änderung übereinstimmt.
 
 ### PR-Plan (empfohlen, klein & linear)
 
@@ -943,6 +950,7 @@ nightly-Abhängigkeiten.
 - `cargo clippy -D warnings`
 - deterministische Snapshots (keine Umgebungsabhängigkeiten)
 - Kein `unsafe`, keine `unwrap`/`expect` in Lib-Logik
+- `CHANGELOG.md` gepflegt (Unreleased-Eintrag, PROOF_VERSION-/Snapshot-Hinweis)
 - Review-Checklist: Endianness, Längenfelder, Fehlerpfade, deterministische Reihenfolge
 
 ### Risiken & Gegenmaßnahmen


### PR DESCRIPTION
## Summary
- add CHANGELOG.md with proof ABI policy, snapshot workflow, and initial Unreleased entry
- document changelog maintenance responsibilities in the README hardening phase, quality gates, and review checklist
- require CI to assert the changelog scaffold is present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8c9daeacc8326b9b33265c9cd08bd