### PR TITLE
Add backend adapters behind feature gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           grep -q '^## \[Unreleased\]' CHANGELOG.md
       - name: Cargo build
         run: cargo build --locked
+      - name: Cargo build (backend feature)
+        run: cargo build --locked --features backend-rpp-stark
       - name: Cargo clippy
         run: cargo clippy --locked -- -D warnings
       - name: Cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ All notable changes to `rpp-stark` are documented in this file. The structure fo
 
 - Proof envelope, transcript, and Merkle bundle serialization are frozen at `PROOF_VERSION = 1`; deterministic snapshots gate regressions in `tests/snapshots/proof_artifacts__execution_proof_artifacts.snap`.
 
+### Added
+
+- Optional `backend-rpp-stark` feature exposing chain-integration adapters for
+  felts, digests and deterministic hashing, including proof-size limit mapping
+  helpers and STWO fixture tests.
+
 ### Changed
 
 - Raised the minimum supported Rust version (MSRV) and CI toolchain to 1.79 to align with deterministic builds (see `RELEASE_NOTES.md`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 audit-lde = []
 audit-lde-hisec = ["audit-lde"]
 parallel = ["rayon"]
+backend-rpp-stark = []
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -962,9 +962,19 @@ nightly-Abhängigkeiten.
 
 ### Spätere Chain-Integration (separat)
 
-- Adapter-Layer (Felt/Digest/Hasher), Feature-Gate `backend-rpp-stark`.
+- Adapter-Layer (Felt/Digest/Hasher) hinter dem Feature-Gate
+  `backend-rpp-stark`: die Wrapper `backend::Felt`, `backend::Digest` und
+  `backend::Hasher` spiegeln die Feld- und Hash-Primitiven der Lib. Der Hasher
+  stellt das Domain-Tag `rpp-stark:blake2s:commit` via
+  `backend::Hasher::DOMAIN_TAG` bereit und bietet mit
+  `backend::Hasher::new_with_domain_tag()` sowie
+  `backend::ChainHasher::absorb_domain_tag(...)` deterministisches Seeding für
+  32-Byte-Digests.
+- Mapping-Helfer: `backend::node_limit_to_params_kb(...)`,
+  `backend::params_limit_to_node_bytes(...)` und
+  `backend::ensure_proof_size_consistency(...)` halten das Proof-Size-Gate und
+  das Node-Limit synchron.
 - Zwei CLI-Binaries (`prove`, `verify`) für manuelle Tests.
-- Proof-Size-Gate an Node-Config mappen.
 
 ### Roadmap-Erweiterung – Kette komplett (Integration & Betriebsreife)
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,271 @@
+//! Chain integration adapters for the `rpp-stark` backend.
+//!
+//! The types exposed here bridge the core primitives to the lightweight
+//! interfaces that the node expects when the optional `backend-rpp-stark`
+//! feature is enabled.  The adapters remain allocation-free and retain the
+//! deterministic behaviour of the reference implementation.
+
+use crate::field::prime_field::{
+    CanonicalSerialize, ConstantTimeAssertions, FieldConstraintError, FieldDeserializeError,
+    FieldElement,
+};
+use crate::hash::config::BLAKE2S_COMMITMENT_DOMAIN_TAG;
+use crate::hash::deterministic::{
+    Blake2sInteropHasher, Hash as DeterministicHash, Hasher as DeterministicHasher,
+};
+use crate::params::StarkParams;
+
+/// Error emitted when converting between canonical field encodings and the
+/// chain-specific felt wrapper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeltConversionError {
+    /// Canonicality constraint reported by the core field implementation.
+    Constraint(FieldConstraintError),
+    /// Deserialisation failure due to a non-canonical byte representation.
+    Deserialize(FieldDeserializeError),
+}
+
+impl From<FieldConstraintError> for FeltConversionError {
+    fn from(error: FieldConstraintError) -> Self {
+        Self::Constraint(error)
+    }
+}
+
+impl From<FieldDeserializeError> for FeltConversionError {
+    fn from(error: FieldDeserializeError) -> Self {
+        Self::Deserialize(error)
+    }
+}
+
+/// Chain-facing felt wrapper around [`FieldElement`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Felt(pub FieldElement);
+
+impl Felt {
+    /// Attempts to wrap a field element after enforcing canonicality.
+    pub fn from_field(element: FieldElement) -> Result<Self, FeltConversionError> {
+        element.assert_canonical()?;
+        Ok(Self(element))
+    }
+
+    /// Returns the inner field element without additional checks.
+    pub fn into_field(self) -> FieldElement {
+        self.0
+    }
+
+    /// Serialises the felt into little-endian bytes accepted by the node.
+    pub fn to_le_bytes(&self) -> Result<[u8; 8], FeltConversionError> {
+        Ok(self.0.to_bytes()?)
+    }
+
+    /// Deserialises the felt from canonical little-endian bytes.
+    pub fn from_le_bytes(bytes: &[u8; 8]) -> Result<Self, FeltConversionError> {
+        let element = FieldElement::from_bytes(bytes)?;
+        Ok(Self(element))
+    }
+}
+
+/// Trait describing the chain-level felt contract.
+pub trait ChainFelt {
+    /// Serialises the felt into canonical little-endian bytes.
+    fn to_chain_bytes(&self) -> Result<[u8; 8], FeltConversionError>;
+    /// Constructs the felt from canonical little-endian bytes.
+    fn from_chain_bytes(bytes: &[u8; 8]) -> Result<Self, FeltConversionError>
+    where
+        Self: Sized;
+    /// Provides access to the wrapped [`FieldElement`].
+    fn as_field(&self) -> &FieldElement;
+}
+
+impl ChainFelt for Felt {
+    fn to_chain_bytes(&self) -> Result<[u8; 8], FeltConversionError> {
+        self.to_le_bytes()
+    }
+
+    fn from_chain_bytes(bytes: &[u8; 8]) -> Result<Self, FeltConversionError> {
+        Self::from_le_bytes(bytes)
+    }
+
+    fn as_field(&self) -> &FieldElement {
+        &self.0
+    }
+}
+
+/// Chain-facing digest wrapper that retains the deterministic 32-byte output of
+/// the Blake2s backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Digest {
+    inner: DeterministicHash,
+}
+
+impl Digest {
+    /// Length in bytes of the canonical digest representation.
+    pub const LENGTH: usize = 32;
+
+    /// Creates a digest adapter from deterministic hash bytes.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self {
+            inner: DeterministicHash::from_bytes(bytes),
+        }
+    }
+
+    /// Wraps an existing deterministic hash value.
+    pub const fn from_hash(hash: DeterministicHash) -> Self {
+        Self { inner: hash }
+    }
+
+    /// Returns the underlying deterministic hash.
+    pub const fn into_hash(self) -> DeterministicHash {
+        self.inner
+    }
+
+    /// Returns a reference to the digest bytes.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        self.inner.as_bytes()
+    }
+
+    /// Consumes the digest and returns the raw byte array.
+    pub const fn into_bytes(self) -> [u8; 32] {
+        self.inner.into_bytes()
+    }
+}
+
+/// Trait describing the chain-level digest contract.
+pub trait ChainDigest {
+    /// Returns the canonical byte representation of the digest.
+    fn as_chain_bytes(&self) -> &[u8; 32];
+    /// Consumes the digest and returns the canonical byte array.
+    fn into_chain_bytes(self) -> [u8; 32];
+}
+
+impl ChainDigest for Digest {
+    fn as_chain_bytes(&self) -> &[u8; 32] {
+        self.as_bytes()
+    }
+
+    fn into_chain_bytes(self) -> [u8; 32] {
+        self.into_bytes()
+    }
+}
+
+/// Deterministic Blake2s hasher seeded with the chain domain tag.
+#[derive(Clone)]
+pub struct Hasher {
+    inner: DeterministicHasher<Blake2sInteropHasher>,
+}
+
+impl Hasher {
+    /// Domain separation tag agreed upon with the node backend.
+    pub const DOMAIN_TAG: &'static [u8] = BLAKE2S_COMMITMENT_DOMAIN_TAG;
+
+    /// Creates a new hasher instance without absorbing the domain tag.
+    pub fn new() -> Self {
+        Self {
+            inner: DeterministicHasher::<Blake2sInteropHasher>::with_backend(),
+        }
+    }
+
+    /// Creates a new hasher instance and immediately absorbs the domain tag.
+    pub fn new_with_domain_tag() -> Self {
+        let mut hasher = Self::new();
+        hasher.absorb_domain_tag();
+        hasher
+    }
+
+    /// Absorbs the canonical domain tag into the hash state.
+    pub fn absorb_domain_tag(&mut self) {
+        self.inner.update(Self::DOMAIN_TAG);
+    }
+
+    /// Absorbs bytes into the deterministic Blake2s state.
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    /// Finalises the hasher and returns the chain digest wrapper.
+    pub fn finalize(self) -> Digest {
+        Digest::from_hash(self.inner.finalize())
+    }
+}
+
+/// Trait describing the chain-level hashing contract.
+pub trait ChainHasher {
+    /// Associated digest type returned by the hasher.
+    type Digest: ChainDigest;
+
+    /// Returns the domain separation tag applied by the hasher.
+    fn domain_tag() -> &'static [u8];
+    /// Absorbs the canonical domain separation tag.
+    fn absorb_domain_tag(&mut self);
+    /// Absorbs bytes into the hash state.
+    fn update(&mut self, data: &[u8]);
+    /// Finalises the hash computation.
+    fn finalize(self) -> Self::Digest;
+}
+
+impl ChainHasher for Hasher {
+    type Digest = Digest;
+
+    fn domain_tag() -> &'static [u8] {
+        Self::DOMAIN_TAG
+    }
+
+    fn absorb_domain_tag(&mut self) {
+        Hasher::absorb_domain_tag(self);
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        Hasher::update(self, data);
+    }
+
+    fn finalize(self) -> Self::Digest {
+        Hasher::finalize(self)
+    }
+}
+
+/// Errors that can be emitted while mapping proof size limits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofSizeMappingError {
+    /// Overflow when converting from kilobytes to bytes.
+    Overflow { max_size_kb: u32 },
+    /// Parameter and node limits disagree after applying ceiling semantics.
+    Mismatch { params_kb: u32, expected_kb: u32 },
+}
+
+/// Converts the proof size limit from kilobytes (stored in [`StarkParams`]) to
+/// bytes as enforced by the node configuration.
+pub fn params_limit_to_node_bytes(params: &StarkParams) -> Result<u32, ProofSizeMappingError> {
+    params
+        .proof()
+        .max_size_kb
+        .checked_mul(1024)
+        .ok_or(ProofSizeMappingError::Overflow {
+            max_size_kb: params.proof().max_size_kb,
+        })
+}
+
+/// Converts the node proof size limit in bytes to the canonical kilobyte value
+/// stored inside [`StarkParams`].  The node applies ceiling semantics when
+/// rounding to kilobytes.
+pub fn node_limit_to_params_kb(node_limit_bytes: u32) -> u32 {
+    node_limit_bytes.div_ceil(1024)
+}
+
+/// Ensures that the proof size limit stored in [`StarkParams`] matches the
+/// configured node limit after applying canonical rounding semantics.
+pub fn ensure_proof_size_consistency(
+    params: &StarkParams,
+    node_limit_bytes: u32,
+) -> Result<(), ProofSizeMappingError> {
+    let expected_kb = node_limit_to_params_kb(node_limit_bytes);
+    let params_kb = params.proof().max_size_kb;
+    if params_kb != expected_kb {
+        return Err(ProofSizeMappingError::Mismatch {
+            params_kb,
+            expected_kb,
+        });
+    }
+    // Also check for overflow when mapping back to bytes to catch large values.
+    let _ = params_limit_to_node_bytes(params)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub mod transcript;
 pub mod utils;
 pub mod vrf;
 
+#[cfg(feature = "backend-rpp-stark")]
+pub mod backend;
+
 use config::{ProofSystemConfig, ProverContext, VerifierContext};
 use proof::aggregation;
 use proof::prover;

--- a/tests/backend_interop.rs
+++ b/tests/backend_interop.rs
@@ -1,0 +1,178 @@
+#![cfg(feature = "backend-rpp-stark")]
+
+use std::convert::TryInto;
+use std::fs;
+use std::path::Path;
+
+use rpp_stark::backend::{
+    ensure_proof_size_consistency, node_limit_to_params_kb, params_limit_to_node_bytes,
+    ChainDigest, ChainFelt, ChainHasher, Digest, Felt, Hasher, ProofSizeMappingError,
+};
+use rpp_stark::field::prime_field::FieldElement;
+use rpp_stark::params::StarkParamsBuilder;
+use serde::Deserialize;
+
+#[derive(Debug)]
+struct HashVectorFixture {
+    leaves: Vec<Vec<u8>>,
+    root: [u8; Digest::LENGTH],
+}
+
+#[derive(Deserialize)]
+struct HashVectorFixtureRaw {
+    leaves: Vec<String>,
+    root: String,
+}
+
+fn decode_hex(input: &str) -> Result<Vec<u8>, String> {
+    if input.len() % 2 != 0 {
+        return Err(format!("hex payload has odd length: {}", input.len()));
+    }
+    let mut out = Vec::with_capacity(input.len() / 2);
+    let bytes = input.as_bytes();
+    for chunk in bytes.chunks(2) {
+        let high = (chunk[0] as char)
+            .to_digit(16)
+            .ok_or_else(|| format!("invalid hex char '{}' in {}", chunk[0] as char, input))?;
+        let low = (chunk[1] as char)
+            .to_digit(16)
+            .ok_or_else(|| format!("invalid hex char '{}' in {}", chunk[1] as char, input))?;
+        out.push(((high << 4) | low) as u8);
+    }
+    Ok(out)
+}
+
+fn load_fixture(base: &Path) -> Result<HashVectorFixture, String> {
+    let json_path = base.join("hash_vectors.json");
+    let bin_path = base.join("hash_vectors.bin");
+
+    let json_data = fs::read_to_string(&json_path)
+        .map_err(|err| format!("failed to read {json_path:?}: {err}"))?;
+    let fixture: HashVectorFixtureRaw = serde_json::from_str(&json_data)
+        .map_err(|err| format!("failed to decode fixture JSON: {err}"))?;
+
+    let leaves = fixture
+        .leaves
+        .iter()
+        .map(|entry| decode_hex(entry))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let root_bytes = decode_hex(&fixture.root)?;
+    if root_bytes.len() != Digest::LENGTH {
+        return Err(format!(
+            "expected {}-byte root, got {}",
+            Digest::LENGTH,
+            root_bytes.len()
+        ));
+    }
+    let root: [u8; Digest::LENGTH] = root_bytes
+        .as_slice()
+        .try_into()
+        .expect("length checked above");
+
+    if let Ok(bin_root) = fs::read(&bin_path) {
+        if bin_root.len() == Digest::LENGTH && bin_root.as_slice() != root {
+            return Err("binary and JSON root mismatch".to_string());
+        }
+    }
+
+    Ok(HashVectorFixture { leaves, root })
+}
+
+#[test]
+fn felt_roundtrip_matches_field_encoding() {
+    let element = FieldElement(123_456_789);
+    let felt = Felt::from_field(element).expect("canonical element must wrap");
+    let bytes = felt.to_chain_bytes().expect("canonical element serialises");
+    let roundtrip = Felt::from_chain_bytes(&bytes).expect("bytes must decode");
+    assert_eq!(roundtrip.as_field(), &element);
+}
+
+#[test]
+fn chain_hasher_matches_stwo_fixture() {
+    let fixture = load_fixture(Path::new("tests/fixtures/stwo")).expect("fixture must load");
+    let mut flattened = Vec::new();
+    for leaf in &fixture.leaves {
+        flattened.extend_from_slice(leaf);
+    }
+
+    assert_eq!(
+        Hasher::domain_tag(),
+        rpp_stark::hash::config::BLAKE2S_COMMITMENT_DOMAIN_TAG
+    );
+
+    let mut hasher = Hasher::new();
+    for leaf in &fixture.leaves {
+        ChainHasher::update(&mut hasher, leaf);
+    }
+    let digest = ChainHasher::finalize(hasher);
+    assert_eq!(digest.as_chain_bytes(), &fixture.root);
+    assert_eq!(digest.as_chain_bytes().len(), Digest::LENGTH);
+
+    // Direct hashing of the flattened payload should match the streamed digest.
+    let mut direct = Hasher::new();
+    ChainHasher::update(&mut direct, &flattened);
+    let direct_digest = ChainHasher::finalize(direct);
+    assert_eq!(direct_digest.into_chain_bytes(), fixture.root);
+
+    // Applying the domain tag explicitly matches the convenience constructor.
+    let mut tagged = Hasher::new();
+    ChainHasher::absorb_domain_tag(&mut tagged);
+    ChainHasher::update(&mut tagged, &flattened);
+    let tagged_digest = ChainHasher::finalize(tagged);
+
+    let mut ctor_tagged = Hasher::new_with_domain_tag();
+    ChainHasher::update(&mut ctor_tagged, &flattened);
+    let ctor_digest = ChainHasher::finalize(ctor_tagged);
+    assert_eq!(tagged_digest.as_chain_bytes(), ctor_digest.as_chain_bytes());
+}
+
+#[test]
+fn proof_size_mapping_roundtrip() {
+    let node_limit_bytes = 1_500_000u32;
+    let expected_kb = node_limit_to_params_kb(node_limit_bytes);
+
+    let mut builder = StarkParamsBuilder::new();
+    builder.proof.max_size_kb = expected_kb;
+    let params = builder.build().expect("builder must yield params");
+
+    ensure_proof_size_consistency(&params, node_limit_bytes)
+        .expect("mapping should consider rounding semantics");
+
+    let params_bytes = params_limit_to_node_bytes(&params).expect("bytes should fit");
+    assert!(params_bytes >= node_limit_bytes);
+    assert!(params_bytes - node_limit_bytes < 1024);
+}
+
+#[test]
+fn proof_size_mapping_detects_mismatch() {
+    let node_limit_bytes = 1_500_000u32;
+    let mut builder = StarkParamsBuilder::new();
+    builder.proof.max_size_kb = node_limit_to_params_kb(node_limit_bytes) - 1;
+    let params = builder.build().expect("builder must yield params");
+
+    let err = ensure_proof_size_consistency(&params, node_limit_bytes)
+        .expect_err("mismatch should be detected");
+    assert_eq!(
+        err,
+        ProofSizeMappingError::Mismatch {
+            params_kb: params.proof().max_size_kb,
+            expected_kb: node_limit_to_params_kb(node_limit_bytes),
+        }
+    );
+}
+
+#[test]
+fn proof_size_mapping_overflow_is_reported() {
+    let mut builder = StarkParamsBuilder::new();
+    builder.proof.max_size_kb = u32::MAX;
+    let params = builder.build().expect("builder must yield params");
+
+    let err = params_limit_to_node_bytes(&params).expect_err("overflow must be flagged");
+    assert_eq!(
+        err,
+        ProofSizeMappingError::Overflow {
+            max_size_kb: u32::MAX
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- add an optional `backend-rpp-stark` feature with backend adapters for felts, digests, hashing and proof-size mapping helpers
- add README and CHANGELOG notes plus interoperability tests validating STWO vectors
- wire the backend feature into CI with a dedicated build job

## Testing
- cargo test
- cargo test --features backend-rpp-stark

------
https://chatgpt.com/codex/tasks/task_e_68e8ccc51c5c8326ba7bb6056d0e2510