### PR TITLE
Add telemetry failure matrix coverage

### DIFF
--- a/tests/fail_matrix.rs
+++ b/tests/fail_matrix.rs
@@ -14,12 +14,15 @@ mod merkle;
 mod ood;
 #[path = "fail_matrix/snapshots.rs"]
 mod snapshots;
+#[path = "fail_matrix/telemetry.rs"]
+mod telemetry;
 
 pub use fixture::{
     corrupt_merkle_path, duplicate_composition_index, duplicate_trace_index,
     flip_composition_leaf_byte, flip_header_version, flip_ood_composition_value,
     flip_ood_trace_core_value, flip_param_digest_byte, flip_public_digest_byte,
-    mismatch_composition_indices, mismatch_trace_indices, mismatch_trace_root,
+    mismatch_composition_indices, mismatch_telemetry_body_length, mismatch_telemetry_header_length,
+    mismatch_telemetry_integrity_digest, mismatch_trace_indices, mismatch_trace_root,
     perturb_fri_fold_challenge, swap_composition_indices, swap_trace_indices, truncate_trace_paths,
     FailMatrixFixture, MutatedProof,
 };

--- a/tests/fail_matrix/snapshots/fail_matrix__telemetry__telemetry_rejects_body_length_mismatch__frame.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__telemetry__telemetry_rejects_body_length_mismatch__frame.snap
@@ -1,0 +1,5 @@
+---
+source: tests/fail_matrix/telemetry.rs
+expression: hex_bytes(&telemetry_bytes)
+---
+ee000000f00b0200020c0020000000400012769de887a74ef90dfd1e7cb75dc9660ae8f8986c9d562a5f4e72d09c86610f

--- a/tests/fail_matrix/snapshots/fail_matrix__telemetry__telemetry_rejects_header_length_mismatch__frame.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__telemetry__telemetry_rejects_header_length_mismatch__frame.snap
@@ -1,0 +1,5 @@
+---
+source: tests/fail_matrix/telemetry.rs
+expression: hex_bytes(&telemetry_bytes)
+---
+f2000000e00b0200020c0020000000400012769de887a74ef90dfd1e7cb75dc9660ae8f8986c9d562a5f4e72d09c86610f

--- a/tests/fail_matrix/snapshots/fail_matrix__telemetry__telemetry_rejects_integrity_digest_mismatch__frame.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__telemetry__telemetry_rejects_integrity_digest_mismatch__frame.snap
@@ -1,0 +1,5 @@
+---
+source: tests/fail_matrix/telemetry.rs
+expression: hex_bytes(&telemetry_bytes)
+---
+ee000000e00b0200020c0020000000400013769de887a74ef90dfd1e7cb75dc9660ae8f8986c9d562a5f4e72d09c86610f

--- a/tests/fail_matrix/telemetry.rs
+++ b/tests/fail_matrix/telemetry.rs
@@ -1,0 +1,176 @@
+use insta::assert_snapshot;
+use rpp_stark::config::ProofKind as ConfigProofKind;
+use rpp_stark::proof::types::VerifyError;
+use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::utils::serialization::ProofBytes;
+use std::convert::TryInto;
+
+use super::{
+    mismatch_telemetry_body_length, mismatch_telemetry_header_length,
+    mismatch_telemetry_integrity_digest, FailMatrixFixture,
+};
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
+}
+
+fn telemetry_frame_bytes(bytes: &ProofBytes) -> Option<Vec<u8>> {
+    let slice = bytes.as_slice();
+    let mut cursor = 0usize;
+    cursor += 2; // version
+    cursor += 1; // kind
+    cursor += 32; // param digest
+    cursor += 32; // air spec id
+
+    let public_len = u32::from_le_bytes(
+        slice[cursor..cursor + 4]
+            .try_into()
+            .expect("public length slice"),
+    ) as usize;
+    cursor += 4; // public length
+    cursor += public_len; // public bytes
+
+    cursor += 32; // public digest
+    cursor += 32; // trace commitment digest
+
+    let composition_flag = slice[cursor];
+    cursor += 1;
+    if composition_flag == 1 {
+        cursor += 32; // composition digest
+    }
+
+    let merkle_len = u32::from_le_bytes(
+        slice[cursor..cursor + 4]
+            .try_into()
+            .expect("merkle length slice"),
+    ) as usize;
+    cursor += 4;
+
+    let fri_len = u32::from_le_bytes(
+        slice[cursor..cursor + 4]
+            .try_into()
+            .expect("fri length slice"),
+    ) as usize;
+    cursor += 4;
+
+    let openings_len = u32::from_le_bytes(
+        slice[cursor..cursor + 4]
+            .try_into()
+            .expect("openings length slice"),
+    ) as usize;
+    cursor += 4;
+
+    let telemetry_flag = slice[cursor];
+    cursor += 1;
+    if telemetry_flag == 0 {
+        return None;
+    }
+
+    let telemetry_len = u32::from_le_bytes(
+        slice[cursor..cursor + 4]
+            .try_into()
+            .expect("telemetry length slice"),
+    ) as usize;
+    cursor += 4;
+
+    let header_len = cursor;
+    let start = header_len + merkle_len + fri_len + openings_len;
+    let end = start + telemetry_len;
+    Some(slice[start..end].to_vec())
+}
+
+#[test]
+fn telemetry_rejects_header_length_mismatch() {
+    let fixture = FailMatrixFixture::new();
+    let Some(mutated_bytes) = mismatch_telemetry_header_length(&fixture.proof()) else {
+        eprintln!("fixture does not expose telemetry; skipping test");
+        return;
+    };
+
+    let public_inputs = fixture.public_inputs();
+    let config = fixture.config();
+    let context = fixture.verifier_context();
+
+    let report = verify_proof_bytes(
+        ConfigProofKind::Tx,
+        &public_inputs,
+        &mutated_bytes,
+        &config,
+        &context,
+    )
+    .expect("report produced");
+
+    let error = report.error.expect("expected verification failure");
+    assert!(matches!(error, VerifyError::HeaderLengthMismatch { .. }));
+
+    let telemetry_bytes =
+        telemetry_frame_bytes(&mutated_bytes).expect("telemetry frame bytes available");
+    assert_snapshot!(
+        "telemetry_rejects_header_length_mismatch__frame",
+        hex_bytes(&telemetry_bytes)
+    );
+}
+
+#[test]
+fn telemetry_rejects_body_length_mismatch() {
+    let fixture = FailMatrixFixture::new();
+    let Some(mutated_bytes) = mismatch_telemetry_body_length(&fixture.proof()) else {
+        eprintln!("fixture does not expose telemetry; skipping test");
+        return;
+    };
+
+    let public_inputs = fixture.public_inputs();
+    let config = fixture.config();
+    let context = fixture.verifier_context();
+
+    let report = verify_proof_bytes(
+        ConfigProofKind::Tx,
+        &public_inputs,
+        &mutated_bytes,
+        &config,
+        &context,
+    )
+    .expect("report produced");
+
+    let error = report.error.expect("expected verification failure");
+    assert!(matches!(error, VerifyError::BodyLengthMismatch { .. }));
+
+    let telemetry_bytes =
+        telemetry_frame_bytes(&mutated_bytes).expect("telemetry frame bytes available");
+    assert_snapshot!(
+        "telemetry_rejects_body_length_mismatch__frame",
+        hex_bytes(&telemetry_bytes)
+    );
+}
+
+#[test]
+fn telemetry_rejects_integrity_digest_mismatch() {
+    let fixture = FailMatrixFixture::new();
+    let Some(mutated_bytes) = mismatch_telemetry_integrity_digest(&fixture.proof()) else {
+        eprintln!("fixture does not expose telemetry; skipping test");
+        return;
+    };
+
+    let public_inputs = fixture.public_inputs();
+    let config = fixture.config();
+    let context = fixture.verifier_context();
+
+    let report = verify_proof_bytes(
+        ConfigProofKind::Tx,
+        &public_inputs,
+        &mutated_bytes,
+        &config,
+        &context,
+    )
+    .expect("report produced");
+
+    let error = report.error.expect("expected verification failure");
+    assert!(matches!(error, VerifyError::IntegrityDigestMismatch));
+
+    let telemetry_bytes =
+        telemetry_frame_bytes(&mutated_bytes).expect("telemetry frame bytes available");
+    assert_snapshot!(
+        "telemetry_rejects_integrity_digest_mismatch__frame",
+        hex_bytes(&telemetry_bytes)
+    );
+}


### PR DESCRIPTION
## Summary
- add helpers that reserialize proofs after mutating telemetry length and digest fields
- cover telemetry header/body length and integrity digest mismatches in the fail matrix
- snapshot the mutated telemetry frames for the new failure scenarios

## Testing
- `cargo test telemetry_rejects --tests`
- `cargo insta review`


------
https://chatgpt.com/codex/tasks/task_e_68e8d948cf84832680cfa9cd3535d101