### PR TITLE
Refactor proof access to use accessor methods

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -214,10 +214,11 @@ fn build_sample_proof(
     let header_bytes = proof
         .serialize_header(&payload)
         .expect("sample proof header serialization");
-    proof.telemetry.body_length = (payload.len() + 32) as u32;
-    proof.telemetry.header_length = header_bytes.len() as u32;
+    let telemetry = proof.telemetry_mut();
+    telemetry.body_length = (payload.len() + 32) as u32;
+    telemetry.header_length = header_bytes.len() as u32;
     let integrity = compute_integrity_digest(&header_bytes, &payload);
-    proof.telemetry.integrity_digest = DigestBytes { bytes: integrity };
+    telemetry.integrity_digest = DigestBytes { bytes: integrity };
 
     proof
 }

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -192,10 +192,11 @@ impl ProofBuilder {
         let payload = serialize_proof_payload(&proof).map_err(VerifyError::from)?;
         let header_bytes = serialize_proof_header(&proof, &payload).map_err(VerifyError::from)?;
 
-        proof.telemetry.header_length = header_bytes.len() as u32;
-        proof.telemetry.body_length = (payload.len() + 32) as u32;
+        let telemetry = proof.telemetry_mut();
+        telemetry.header_length = header_bytes.len() as u32;
+        telemetry.body_length = (payload.len() + 32) as u32;
         let integrity = compute_integrity_digest(&header_bytes, &payload);
-        proof.telemetry.integrity_digest = DigestBytes { bytes: integrity };
+        telemetry.integrity_digest = DigestBytes { bytes: integrity };
 
         let bytes_total = header_bytes.len() + payload.len() + 32;
         let limit_bytes = (self.params.max_size_kb as usize) * 1024;

--- a/src/proof/prover.rs
+++ b/src/proof/prover.rs
@@ -300,11 +300,12 @@ pub fn build_envelope(
     let header_bytes = proof
         .serialize_header(&body_payload)
         .map_err(ProverError::from)?;
-    proof.telemetry.body_length = (body_payload.len() + 32) as u32;
-    proof.telemetry.header_length = header_bytes.len() as u32;
+    let telemetry = proof.telemetry_mut();
+    telemetry.body_length = (body_payload.len() + 32) as u32;
+    telemetry.header_length = header_bytes.len() as u32;
 
     let integrity_digest = compute_integrity_digest(&header_bytes, &body_payload);
-    proof.telemetry.integrity_digest = DigestBytes {
+    telemetry.integrity_digest = DigestBytes {
         bytes: integrity_digest,
     };
 

--- a/src/proof/ser.rs
+++ b/src/proof/ser.rs
@@ -206,7 +206,10 @@ pub fn serialize_proof(proof: &Proof) -> Result<Vec<u8>, SerError> {
         ));
     }
 
-    match (proof.composition_commit(), proof.openings().composition.as_ref()) {
+    match (
+        proof.composition_commit(),
+        proof.openings().composition.as_ref(),
+    ) {
         (Some(commit), Some(_)) => {
             if commit.bytes != proof.merkle().aux_root {
                 return Err(SerError::invalid_value(

--- a/tests/fail_matrix/fri.rs
+++ b/tests/fail_matrix/fri.rs
@@ -33,7 +33,7 @@ fn fri_rejects_fold_challenge_tampering() {
     assert_debug_snapshot!("fri_rejects_fold_challenge_tampering_issue", issue);
     assert_debug_snapshot!(
         "fri_rejects_fold_challenge_tampering_challenges",
-        mutated.proof.fri_proof.fold_challenges
+        mutated.proof.fri_proof().fold_challenges.clone()
     );
 
     assert!(

--- a/tests/fail_matrix/indices.rs
+++ b/tests/fail_matrix/indices.rs
@@ -31,7 +31,7 @@ fn trace_rejects_unsorted_indices() {
 
     assert_debug_snapshot!(
         "trace_rejects_unsorted_indices",
-        &mutated.proof.openings.trace.indices
+        &mutated.proof.openings().trace.indices
     );
 }
 
@@ -58,7 +58,7 @@ fn trace_rejects_duplicate_indices() {
 
     assert_debug_snapshot!(
         "trace_rejects_duplicate_indices",
-        &mutated.proof.openings.trace.indices
+        &mutated.proof.openings().trace.indices
     );
 }
 
@@ -85,7 +85,7 @@ fn trace_rejects_mismatched_indices() {
 
     assert_debug_snapshot!(
         "trace_rejects_mismatched_indices",
-        &mutated.proof.openings.trace.indices
+        &mutated.proof.openings().trace.indices
     );
 }
 
@@ -117,7 +117,7 @@ fn composition_rejects_unsorted_indices() {
         "composition_rejects_unsorted_indices",
         &mutated
             .proof
-            .openings
+            .openings()
             .composition
             .as_ref()
             .expect("composition openings available")
@@ -153,7 +153,7 @@ fn composition_rejects_duplicate_indices() {
         "composition_rejects_duplicate_indices",
         &mutated
             .proof
-            .openings
+            .openings()
             .composition
             .as_ref()
             .expect("composition openings available")
@@ -189,7 +189,7 @@ fn composition_rejects_mismatched_indices() {
         "composition_rejects_mismatched_indices",
         &mutated
             .proof
-            .openings
+            .openings()
             .composition
             .as_ref()
             .expect("composition openings available")

--- a/tests/fail_matrix/ood.rs
+++ b/tests/fail_matrix/ood.rs
@@ -29,7 +29,7 @@ fn trace_ood_rejects_core_value_mismatch() {
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::TraceOodMismatch));
 
-    let ood_openings = mutated.proof.openings.out_of_domain.clone();
+    let ood_openings = mutated.proof.openings().out_of_domain.clone();
     assert!(!ood_openings.is_empty(), "mutated proof lost OOD payloads");
 
     assert_debug_snapshot!("trace_ood_mismatch__tampered_out_of_domain", ood_openings);
@@ -59,7 +59,7 @@ fn composition_ood_rejects_value_mismatch() {
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::CompositionOodMismatch));
 
-    let ood_openings = mutated.proof.openings.out_of_domain.clone();
+    let ood_openings = mutated.proof.openings().out_of_domain.clone();
     assert!(!ood_openings.is_empty(), "mutated proof lost OOD payloads");
 
     assert_debug_snapshot!(

--- a/tests/fail_matrix/snapshots.rs
+++ b/tests/fail_matrix/snapshots.rs
@@ -30,35 +30,30 @@ fn freeze_fixture_artifacts() {
     let proof = fixture.proof();
     let config = fixture.config();
 
-    let trace_indices = proof.openings.trace.indices.clone();
-    let composition_indices = proof
-        .openings
-        .composition
-        .as_ref()
-        .map(|c| c.indices.clone());
+    let openings = proof.openings();
+    let trace_indices = openings.trace.indices.clone();
+    let composition_indices = openings.composition.as_ref().map(|c| c.indices.clone());
 
-    let trace_path_lengths = proof
-        .openings
+    let trace_path_lengths = openings
         .trace
         .paths
         .iter()
         .map(|path| path.nodes.len())
         .collect::<Vec<_>>();
-    let composition_path_lengths = proof.openings.composition.as_ref().map(|c| {
+    let composition_path_lengths = openings.composition.as_ref().map(|c| {
         c.paths
             .iter()
             .map(|path| path.nodes.len())
             .collect::<Vec<_>>()
     });
 
-    let fri_query_positions = proof
-        .fri_proof
+    let fri_proof = proof.fri_proof();
+    let fri_query_positions = fri_proof
         .queries
         .iter()
         .map(|query| query.position)
         .collect::<Vec<_>>();
-    let fri_query_path_lengths = proof
-        .fri_proof
+    let fri_query_path_lengths = fri_proof
         .queries
         .iter()
         .map(|query| {
@@ -75,36 +70,33 @@ fn freeze_fixture_artifacts() {
         "proof_bytes_hex": hex_encode(proof_bytes.as_slice()),
         "param_digest_hex": hex_encode(&config.param_digest.0.bytes),
         "roots": {
-            "core": hex_encode(&proof.merkle.core_root),
-            "aux": hex_encode(&proof.merkle.aux_root),
+            "core": hex_encode(&proof.merkle().core_root),
+            "aux": hex_encode(&proof.merkle().aux_root),
             "fri_from_merkle": proof
-                .merkle
+                .merkle()
                 .fri_layer_roots
                 .iter()
                 .map(hex_encode)
                 .collect::<Vec<_>>(),
-            "fri_from_proof": proof
-                .fri_proof
+            "fri_from_proof": fri_proof
                 .layer_roots
                 .iter()
                 .map(hex_encode)
                 .collect::<Vec<_>>(),
-            "final_polynomial_digest": hex_encode(&proof.fri_proof.final_polynomial_digest),
+            "final_polynomial_digest": hex_encode(&fri_proof.final_polynomial_digest),
         },
         "challenges": {
-            "fri_fold": proof
-                .fri_proof
+            "fri_fold": fri_proof
                 .fold_challenges
                 .iter()
                 .map(field_hex)
                 .collect::<Vec<_>>(),
-            "fri_final_polynomial": proof
-                .fri_proof
+            "fri_final_polynomial": fri_proof
                 .final_polynomial
                 .iter()
                 .map(field_hex)
                 .collect::<Vec<_>>(),
-            "deep_oods": proof.fri_proof.deep_oods.as_ref().map(|oods| json!({
+            "deep_oods": fri_proof.deep_oods.as_ref().map(|oods| json!({
                 "point": field_hex(&oods.point),
                 "evaluations": oods
                     .evaluations

--- a/tests/fail_matrix/snapshots/fail_matrix__fri__fri_rejects_fold_challenge_tampering_challenges.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__fri__fri_rejects_fold_challenge_tampering_challenges.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/fri.rs
 assertion_line: 34
-expression: mutated.proof.fri_proof.fold_challenges
+expression: mutated.proof.fri_proof().fold_challenges.clone()
 ---
 [
     FieldElement(

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_duplicate_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_duplicate_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 152
-expression: "&mutated.proof.openings.composition.as_ref().expect(\"composition openings available\").indices"
+expression: "&mutated.proof.openings().composition.as_ref().expect(\"composition openings available\").indices"
 ---
 [
     15,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_mismatched_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_mismatched_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 188
-expression: "&mutated.proof.openings.composition.as_ref().expect(\"composition openings available\").indices"
+expression: "&mutated.proof.openings().composition.as_ref().expect(\"composition openings available\").indices"
 ---
 [
     1000000,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_unsorted_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_unsorted_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 116
-expression: "&mutated.proof.openings.composition.as_ref().expect(\"composition openings available\").indices"
+expression: "&mutated.proof.openings().composition.as_ref().expect(\"composition openings available\").indices"
 ---
 [
     56,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_duplicate_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_duplicate_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 59
-expression: "&mutated.proof.openings.trace.indices"
+expression: "&mutated.proof.openings().trace.indices"
 ---
 [
     15,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_mismatched_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_mismatched_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 86
-expression: "&mutated.proof.openings.trace.indices"
+expression: "&mutated.proof.openings().trace.indices"
 ---
 [
     1000000,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_unsorted_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_unsorted_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 32
-expression: "&mutated.proof.openings.trace.indices"
+expression: "&mutated.proof.openings().trace.indices"
 ---
 [
     56,

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -355,10 +355,11 @@ fn build_envelope(
     let header_bytes = proof
         .serialize_header(&payload)
         .expect("proof header serialization");
-    proof.telemetry.body_length = (payload.len() + 32) as u32;
-    proof.telemetry.header_length = header_bytes.len() as u32;
+    let telemetry = proof.telemetry_mut();
+    telemetry.body_length = (payload.len() + 32) as u32;
+    telemetry.header_length = header_bytes.len() as u32;
     let integrity = compute_integrity_digest(&header_bytes, &payload);
-    proof.telemetry.integrity_digest = DigestBytes { bytes: integrity };
+    telemetry.integrity_digest = DigestBytes { bytes: integrity };
 
     ProofBytes::new(proof.to_bytes().expect("serialize proof"))
 }

--- a/tests/proof_merkle_quaternary.rs
+++ b/tests/proof_merkle_quaternary.rs
@@ -137,7 +137,7 @@ fn quaternary_profile_merkle_tamper_rejected() {
     .expect("proof generation succeeds");
 
     let mut proof = Proof::from_bytes(proof_bytes.as_slice()).expect("decode proof");
-    if let Some(path) = proof.openings.trace.paths.first_mut() {
+    if let Some(path) = proof.openings_mut().trace.paths.first_mut() {
         if let Some(node) = path.nodes.get_mut(1) {
             node.sibling[0] ^= 0x01;
         }

--- a/tests/ser_structures.rs
+++ b/tests/ser_structures.rs
@@ -135,9 +135,10 @@ fn sample_proof() -> Proof {
     let header_bytes =
         serialize_proof_header(&proof, &payload).expect("proof header serialization");
     let integrity = compute_integrity_digest(&header_bytes, &payload);
-    proof.telemetry.header_length = header_bytes.len() as u32;
-    proof.telemetry.body_length = (payload.len() + 32) as u32;
-    proof.telemetry.integrity_digest = DigestBytes { bytes: integrity };
+    let telemetry = proof.telemetry_mut();
+    telemetry.header_length = header_bytes.len() as u32;
+    telemetry.body_length = (payload.len() + 32) as u32;
+    telemetry.integrity_digest = DigestBytes { bytes: integrity };
     proof
 }
 


### PR DESCRIPTION
## Summary
- replace direct field access on `Proof` with accessor and mutator calls across verifier, prover, and helpers
- update tests and fixtures to use the new getter APIs and keep telemetry mutations consistent
- refresh failure-matrix snapshots to reflect the new accessor-based expressions

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e90cd829908326b58159fbf34acf33