### PR TITLE
Use Proof accessors and constructor

### DIFF
--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -135,32 +135,32 @@ impl FriHandle {
 pub struct Proof {
     /// Declared proof version (currently `1`).
     #[serde(with = "proof_version_codec")]
-    pub version: u16,
+    version: u16,
     /// Canonical proof kind stored in the envelope header.
     #[serde(with = "proof_kind_codec")]
-    pub kind: ProofKind,
+    kind: ProofKind,
     /// Parameter digest binding configuration knobs.
-    pub param_digest: ParamDigest,
+    param_digest: ParamDigest,
     /// AIR specification identifier for the proof kind.
-    pub air_spec_id: AirSpecId,
+    air_spec_id: AirSpecId,
     /// Canonical public input encoding.
-    pub public_inputs: Vec<u8>,
+    public_inputs: Vec<u8>,
     /// Digest binding the canonical public-input payload.
-    pub public_digest: DigestBytes,
+    public_digest: DigestBytes,
     /// Digest mirroring the declared trace commitment.
-    pub trace_commit: DigestBytes,
+    trace_commit: DigestBytes,
     /// Optional digest mirroring the declared composition commitment.
-    pub composition_commit: Option<DigestBytes>,
+    composition_commit: Option<DigestBytes>,
     /// Merkle commitment bundle for core, auxiliary and FRI layers.
-    pub merkle: MerkleProofBundle,
+    merkle: MerkleProofBundle,
     /// Out-of-domain opening payloads.
-    pub openings: Openings,
+    openings: Openings,
     /// FRI proof payload accompanying the envelope.
-    pub fri_proof: FriProof,
+    fri_proof: FriProof,
     /// Flag signalling whether the telemetry segment is present in the payload.
-    pub has_telemetry: bool,
+    has_telemetry: bool,
     /// Telemetry frame describing declared lengths and digests.
-    pub telemetry: Telemetry,
+    telemetry: Telemetry,
 }
 
 impl Proof {

--- a/tests/fail_matrix/composition.rs
+++ b/tests/fail_matrix/composition.rs
@@ -34,7 +34,7 @@ fn composition_rejects_leaf_bytes_mismatch() {
 
     let composition = mutated
         .proof
-        .openings
+        .openings()
         .composition
         .as_ref()
         .expect("composition openings available");

--- a/tests/fail_matrix/merkle.rs
+++ b/tests/fail_matrix/merkle.rs
@@ -133,7 +133,7 @@ fn merkle_rejects_header_root_mismatch() {
 fn snapshot_path_nodes(mutated: &MutatedProof) {
     let nodes: Vec<(u8, String)> = mutated
         .proof
-        .openings
+        .openings()
         .trace
         .paths
         .first()
@@ -180,7 +180,7 @@ fn merkle_rejects_corrupted_trace_path() {
 fn snapshot_path_lengths(mutated: &MutatedProof) {
     let lengths: Vec<usize> = mutated
         .proof
-        .openings
+        .openings()
         .trace
         .paths
         .iter()

--- a/tests/proof_artifacts.rs
+++ b/tests/proof_artifacts.rs
@@ -123,35 +123,35 @@ fn snapshot_execution_proof_artifacts() {
     let decoded = decode_proof(&proof_bytes);
 
     let trace_paths: Vec<usize> = decoded
-        .openings
+        .openings()
         .trace
         .paths
         .iter()
         .map(|path| path.nodes.len())
         .collect();
     let composition_paths: Option<Vec<usize>> = decoded
-        .openings
+        .openings()
         .composition
         .as_ref()
         .map(|comp| comp.paths.iter().map(|path| path.nodes.len()).collect());
     let trace_indices = {
-        let mut indices = decoded.openings.trace.indices.clone();
+        let mut indices = decoded.openings().trace.indices.clone();
         indices.sort_unstable();
         indices
     };
-    let composition_indices = decoded.openings.composition.as_ref().map(|comp| {
+    let composition_indices = decoded.openings().composition.as_ref().map(|comp| {
         let mut indices = comp.indices.clone();
         indices.sort_unstable();
         indices
     });
     let fri_positions: Vec<usize> = decoded
-        .fri_proof
+        .fri_proof()
         .queries
         .iter()
         .map(|query| query.position)
         .collect();
     let fri_layer_path_lengths: Vec<usize> = decoded
-        .fri_proof
+        .fri_proof()
         .queries
         .iter()
         .flat_map(|query| query.layers.iter().map(|layer| layer.path.len()))
@@ -165,9 +165,14 @@ fn snapshot_execution_proof_artifacts() {
     let fri_path_summary = summarize_lengths(&fri_layer_path_lengths);
 
     let artifact = serde_json::json!({
-        "trace_root": hex(&decoded.merkle.core_root),
-        "composition_root": hex(&decoded.merkle.aux_root),
-        "fri_roots": decoded.merkle.fri_layer_roots.iter().map(hex).collect::<Vec<_>>(),
+        "trace_root": hex(&decoded.merkle().core_root),
+        "composition_root": hex(&decoded.merkle().aux_root),
+        "fri_roots": decoded
+            .merkle()
+            .fri_layer_roots
+            .iter()
+            .map(hex)
+            .collect::<Vec<_>>(),
         "trace_query_indices": trace_indices,
         "composition_query_indices": composition_indices,
         "fri_query_positions": fri_positions,

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -427,12 +427,13 @@ fn verification_report_flags_public_stage_failure() {
     let config = fixture.config();
     let context = fixture.verifier_context();
     let mut mutated_proof = fixture.proof();
-    if let Some(byte) = mutated_proof.public_inputs.first_mut() {
+    if let Some(byte) = mutated_proof.public_inputs_mut().first_mut() {
         *byte ^= 0x01;
     } else {
         panic!("fixture must contain public input bytes");
     }
-    mutated_proof.public_digest.bytes = compute_public_digest(&mutated_proof.public_inputs);
+    let recomputed_digest = compute_public_digest(mutated_proof.public_inputs());
+    mutated_proof.public_digest_mut().bytes = recomputed_digest;
     let mutated_bytes = reencode_proof(&mut mutated_proof);
     let declared_kind = map_public_to_config_kind(public_inputs.kind());
 

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -616,7 +616,11 @@ fn mutate_header_composition_root(bytes: &ProofBytes) -> ProofBytes {
 
 fn corrupt_fri_layer_root(proof: &Proof) -> ProofBytes {
     let mut mutated = proof.clone();
-    if let Some(root) = mutated.merkle.fri_layer_roots.first_mut() {
+    if let Some(root) = mutated
+        .merkle_mut()
+        .fri_layer_roots
+        .first_mut()
+    {
         if let Some(byte) = root.first_mut() {
             *byte ^= 0x1;
         } else {
@@ -630,7 +634,7 @@ fn corrupt_fri_layer_root(proof: &Proof) -> ProofBytes {
 }
 
 fn mutate_param_digest(proof: &mut Proof) {
-    proof.param_digest.0.bytes[0] ^= 0x1;
+    proof.param_digest_mut().0.bytes[0] ^= 0x1;
 }
 
 fn mutate_public_digest(bytes: &ProofBytes) -> ProofBytes {
@@ -883,7 +887,7 @@ fn verification_rejects_tampered_composition_leaf() {
 
     let mut proof = rpp_stark::Proof::from_bytes(proof_bytes.as_slice()).expect("decode proof");
     let composition = proof
-        .openings
+        .openings_mut()
         .composition
         .as_mut()
         .expect("composition openings present");


### PR DESCRIPTION
## Summary
- hide `Proof` fields and rely on getter/setter helpers
- build proofs via `Proof::from_parts` in serialization and fixtures
- update fixtures to mutate proofs through the accessor API

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e919ee38848326a6fcefb155736657