### PR TITLE
Use telemetry accessors in proof assembly

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -219,10 +219,10 @@ fn build_sample_proof(
         .serialize_header(&payload)
         .expect("sample proof header serialization");
     let telemetry = proof.telemetry_mut();
-    telemetry.body_length = (payload.len() + 32) as u32;
-    telemetry.header_length = header_bytes.len() as u32;
+    telemetry.set_body_length((payload.len() + 32) as u32);
+    telemetry.set_header_length(header_bytes.len() as u32);
     let integrity = compute_integrity_digest(&header_bytes, &payload);
-    telemetry.integrity_digest = DigestBytes { bytes: integrity };
+    telemetry.set_integrity_digest(DigestBytes { bytes: integrity });
 
     proof
 }

--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -217,10 +217,10 @@ impl ProofBuilder {
         let header_bytes = serialize_proof_header(&proof, &payload).map_err(VerifyError::from)?;
 
         let telemetry = proof.telemetry_mut();
-        telemetry.header_length = header_bytes.len() as u32;
-        telemetry.body_length = (payload.len() + 32) as u32;
+        telemetry.set_header_length(header_bytes.len() as u32);
+        telemetry.set_body_length((payload.len() + 32) as u32);
         let integrity = compute_integrity_digest(&header_bytes, &payload);
-        telemetry.integrity_digest = DigestBytes { bytes: integrity };
+        telemetry.set_integrity_digest(DigestBytes { bytes: integrity });
 
         let bytes_total = header_bytes.len() + payload.len() + 32;
         let limit_bytes = (self.params.max_size_kb as usize) * 1024;
@@ -491,7 +491,7 @@ mod tests {
 
         assert!(proof.has_telemetry());
         assert!(proof.composition_commit().is_some());
-        assert!(proof.telemetry().header_length > 0);
+        assert!(proof.telemetry().header_length() > 0);
         assert_ne!(proof.trace_commit().bytes, [0u8; 32]);
 
         proof

--- a/src/proof/prover.rs
+++ b/src/proof/prover.rs
@@ -302,13 +302,13 @@ pub fn build_envelope(
         .serialize_header(&body_payload)
         .map_err(ProverError::from)?;
     let telemetry = proof.telemetry_mut();
-    telemetry.body_length = (body_payload.len() + 32) as u32;
-    telemetry.header_length = header_bytes.len() as u32;
+    telemetry.set_body_length((body_payload.len() + 32) as u32);
+    telemetry.set_header_length(header_bytes.len() as u32);
 
     let integrity_digest = compute_integrity_digest(&header_bytes, &body_payload);
-    telemetry.integrity_digest = DigestBytes {
+    telemetry.set_integrity_digest(DigestBytes {
         bytes: integrity_digest,
-    };
+    });
 
     let total_size = header_bytes.len() + body_payload.len() + 32;
     if total_size > context.limits.max_proof_size_bytes as usize {

--- a/src/proof/ser.rs
+++ b/src/proof/ser.rs
@@ -589,13 +589,13 @@ fn deserialize_openings(bytes: &[u8]) -> Result<Openings, SerError> {
 
 fn serialize_telemetry_frame(telemetry: &Telemetry) -> Result<Vec<u8>, SerError> {
     let mut out = Vec::new();
-    write_u32(&mut out, telemetry.header_length);
-    write_u32(&mut out, telemetry.body_length);
-    write_u8(&mut out, telemetry.fri_parameters.fold);
-    write_u16(&mut out, telemetry.fri_parameters.cap_degree);
-    write_u32(&mut out, telemetry.fri_parameters.cap_size);
-    write_u16(&mut out, telemetry.fri_parameters.query_budget);
-    write_digest(&mut out, &telemetry.integrity_digest.bytes);
+    write_u32(&mut out, telemetry.header_length());
+    write_u32(&mut out, telemetry.body_length());
+    write_u8(&mut out, telemetry.fri_parameters().fold);
+    write_u16(&mut out, telemetry.fri_parameters().cap_degree);
+    write_u32(&mut out, telemetry.fri_parameters().cap_size);
+    write_u16(&mut out, telemetry.fri_parameters().query_budget);
+    write_digest(&mut out, &telemetry.integrity_digest().bytes);
     Ok(out)
 }
 
@@ -910,9 +910,9 @@ mod tests {
             .expect("proof header serialization");
         let integrity = compute_integrity_digest(&header_bytes, &payload);
         let telemetry = proof.telemetry_mut();
-        telemetry.header_length = header_bytes.len() as u32;
-        telemetry.body_length = (payload.len() + 32) as u32;
-        telemetry.integrity_digest = DigestBytes { bytes: integrity };
+        telemetry.set_header_length(header_bytes.len() as u32);
+        telemetry.set_body_length((payload.len() + 32) as u32);
+        telemetry.set_integrity_digest(DigestBytes { bytes: integrity });
 
         proof
     }

--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -481,6 +481,53 @@ pub struct Telemetry {
     pub integrity_digest: DigestBytes,
 }
 
+impl Telemetry {
+    /// Returns the declared header length for the proof payload.
+    pub fn header_length(&self) -> u32 {
+        self.header_length
+    }
+
+    /// Updates the declared header length for the proof payload.
+    pub fn set_header_length(&mut self, value: u32) {
+        self.header_length = value;
+    }
+
+    /// Returns the declared body length for the proof payload.
+    pub fn body_length(&self) -> u32 {
+        self.body_length
+    }
+
+    /// Updates the declared body length for the proof payload.
+    pub fn set_body_length(&mut self, value: u32) {
+        self.body_length = value;
+    }
+
+    /// Returns the mirrored FRI parameters stored in the telemetry frame.
+    pub fn fri_parameters(&self) -> &FriParametersMirror {
+        &self.fri_parameters
+    }
+
+    /// Returns a mutable reference to the mirrored FRI parameters.
+    pub fn fri_parameters_mut(&mut self) -> &mut FriParametersMirror {
+        &mut self.fri_parameters
+    }
+
+    /// Returns the integrity digest covering the header and body payload.
+    pub fn integrity_digest(&self) -> &DigestBytes {
+        &self.integrity_digest
+    }
+
+    /// Returns a mutable reference to the integrity digest.
+    pub fn integrity_digest_mut(&mut self) -> &mut DigestBytes {
+        &mut self.integrity_digest
+    }
+
+    /// Replaces the integrity digest covering the proof payload.
+    pub fn set_integrity_digest(&mut self, digest: DigestBytes) {
+        self.integrity_digest = digest;
+    }
+}
+
 /// Wrapper combining the telemetry presence flag with the telemetry payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TelemetryOption {

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -366,10 +366,10 @@ fn build_envelope(
         .serialize_header(&payload)
         .expect("proof header serialization");
     let telemetry = proof.telemetry_mut();
-    telemetry.body_length = (payload.len() + 32) as u32;
-    telemetry.header_length = header_bytes.len() as u32;
+    telemetry.set_body_length((payload.len() + 32) as u32);
+    telemetry.set_header_length(header_bytes.len() as u32);
     let integrity = compute_integrity_digest(&header_bytes, &payload);
-    telemetry.integrity_digest = DigestBytes { bytes: integrity };
+    telemetry.set_integrity_digest(DigestBytes { bytes: integrity });
 
     ProofBytes::new(proof.to_bytes().expect("serialize proof"))
 }

--- a/tests/ser_structures.rs
+++ b/tests/ser_structures.rs
@@ -141,9 +141,9 @@ fn sample_proof() -> Proof {
         serialize_proof_header(&proof, &payload).expect("proof header serialization");
     let integrity = compute_integrity_digest(&header_bytes, &payload);
     let telemetry = proof.telemetry_mut();
-    telemetry.header_length = header_bytes.len() as u32;
-    telemetry.body_length = (payload.len() + 32) as u32;
-    telemetry.integrity_digest = DigestBytes { bytes: integrity };
+    telemetry.set_header_length(header_bytes.len() as u32);
+    telemetry.set_body_length((payload.len() + 32) as u32);
+    telemetry.set_integrity_digest(DigestBytes { bytes: integrity });
     proof
 }
 


### PR DESCRIPTION
## Summary
- add getter and setter helpers to `Telemetry` and update serialization and verification to consume them
- switch proof assembly code paths and tests to mutate telemetry data through the new accessors instead of direct fields

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e92672d0988326a8793658f73ee3d3