### PR TITLE
Use Proof::from_parts when cloning proofs for mutation

### DIFF
--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -294,6 +294,31 @@ impl Proof {
         &mut self.telemetry
     }
 
+    /// Clones the proof by reassembling all sections through [`Proof::from_parts`].
+    pub fn clone_using_parts(&self) -> Self {
+        let binding = CompositionBinding::new(
+            *self.kind(),
+            self.air_spec_id().clone(),
+            self.public_inputs().to_vec(),
+            self.composition_commit().cloned(),
+        );
+        let openings_descriptor =
+            OpeningsDescriptor::new(self.merkle().clone(), self.openings().clone());
+        let fri_handle = FriHandle::new(self.fri_proof().clone());
+        let telemetry_option = TelemetryOption::new(self.has_telemetry(), self.telemetry().clone());
+
+        Proof::from_parts(
+            self.version(),
+            self.param_digest().clone(),
+            self.public_digest().clone(),
+            self.trace_commit().clone(),
+            binding,
+            openings_descriptor,
+            fri_handle,
+            telemetry_option,
+        )
+    }
+
     /// Reassembles a proof from the provided building blocks.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -524,7 +524,7 @@ fn precheck_body(
             });
         }
 
-        let mut canonical = proof.clone();
+        let mut canonical = proof.clone_using_parts();
         let canonical_telemetry = canonical.telemetry_mut();
         canonical_telemetry.set_header_length(0);
         canonical_telemetry.set_body_length(0);

--- a/tests/air_end_to_end.rs
+++ b/tests/air_end_to_end.rs
@@ -71,7 +71,7 @@ fn fri_pipeline_rejects_alpha_tampering() {
         .challenge_field(TranscriptLabel::CompChallengeA)
         .expect("comp alpha");
 
-    let mut tampered = fixture.proof.clone();
+    let mut tampered = fixture.proof.clone_using_parts();
     tampered.fold_challenges[0] = tampered.fold_challenges[0].add(&FieldElement::ONE);
 
     let err = fri_verify(&tampered, &fixture.params, &mut verifier_transcript)
@@ -98,7 +98,7 @@ fn fri_pipeline_rejects_merkle_path_tampering() {
         .challenge_field(TranscriptLabel::CompChallengeA)
         .expect("comp alpha");
 
-    let mut tampered = fixture.proof.clone();
+    let mut tampered = fixture.proof.clone_using_parts();
     tampered.queries[0].layers[0].path[0].siblings[0] = [0u8; DIGEST_SIZE];
 
     let err = fri_verify(&tampered, &fixture.params, &mut verifier_transcript)

--- a/tests/air_end_to_end.rs
+++ b/tests/air_end_to_end.rs
@@ -71,7 +71,7 @@ fn fri_pipeline_rejects_alpha_tampering() {
         .challenge_field(TranscriptLabel::CompChallengeA)
         .expect("comp alpha");
 
-    let mut tampered = fixture.proof.clone_using_parts();
+    let mut tampered = fixture.proof.clone();
     tampered.fold_challenges[0] = tampered.fold_challenges[0].add(&FieldElement::ONE);
 
     let err = fri_verify(&tampered, &fixture.params, &mut verifier_transcript)
@@ -98,7 +98,7 @@ fn fri_pipeline_rejects_merkle_path_tampering() {
         .challenge_field(TranscriptLabel::CompChallengeA)
         .expect("comp alpha");
 
-    let mut tampered = fixture.proof.clone_using_parts();
+    let mut tampered = fixture.proof.clone();
     tampered.queries[0].layers[0].path[0].siblings[0] = [0u8; DIGEST_SIZE];
 
     let err = fri_verify(&tampered, &fixture.params, &mut verifier_transcript)

--- a/tests/fail_matrix/fixture.rs
+++ b/tests/fail_matrix/fixture.rs
@@ -97,7 +97,7 @@ impl FailMatrixFixture {
 
     /// Returns the decoded proof container.
     pub fn proof(&self) -> Proof {
-        self.proof.clone()
+        self.proof.clone_using_parts()
     }
 
     /// Returns the configured proof system configuration.
@@ -157,7 +157,7 @@ fn build_witness(seed: FieldElement, rows: usize) -> Vec<u8> {
 
 fn reencode_proof(proof: &mut Proof) -> ProofBytes {
     if proof.has_telemetry() {
-        let mut canonical = proof.clone();
+        let mut canonical = proof.clone_using_parts();
         let telemetry = canonical.telemetry_mut();
         telemetry.set_header_length(0);
         telemetry.set_body_length(0);
@@ -186,7 +186,7 @@ where
         return None;
     }
 
-    let mut mutated = proof.clone();
+    let mut mutated = proof.clone_using_parts();
     let _ = reencode_proof(&mut mutated);
     mutator(mutated.telemetry_mut());
 
@@ -232,14 +232,14 @@ pub fn mismatch_telemetry_integrity_digest(proof: &Proof) -> Option<ProofBytes> 
 
 /// Flips the proof header version field.
 pub fn flip_header_version(proof: &Proof) -> ProofBytes {
-    let mut mutated = proof.clone();
+    let mut mutated = proof.clone_using_parts();
     *mutated.version_mut() ^= 1;
     reencode_proof(&mut mutated)
 }
 
 /// Corrupts a single byte inside the parameter digest.
 pub fn flip_param_digest_byte(proof: &Proof) -> ProofBytes {
-    let mut mutated = proof.clone();
+    let mut mutated = proof.clone_using_parts();
     mutated.param_digest_mut().0.bytes[0] ^= 0x01;
     reencode_proof(&mut mutated)
 }
@@ -352,7 +352,7 @@ fn mutate_proof<F>(proof: &Proof, mutator: F) -> MutatedProof
 where
     F: FnOnce(&mut Proof),
 {
-    let mut mutated = proof.clone();
+    let mut mutated = proof.clone_using_parts();
     mutator(&mut mutated);
     let bytes = reencode_proof(&mut mutated);
     MutatedProof {

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -185,7 +185,7 @@ fn decode_proof(bytes: &ProofBytes) -> Proof {
 
 fn reencode_proof(proof: &mut Proof) -> ProofBytes {
     if proof.has_telemetry() {
-        let mut canonical = proof.clone();
+        let mut canonical = proof.clone_using_parts();
         let telemetry = canonical.telemetry_mut();
         telemetry.set_header_length(0);
         telemetry.set_body_length(0);
@@ -272,7 +272,7 @@ fn verification_report_records_total_bytes_and_telemetry() {
         "telemetry lengths must sum to total bytes plus the integrity digest"
     );
 
-    let mut canonical = report.proof.clone();
+    let mut canonical = report.proof.clone_using_parts();
     let canonical_telemetry = canonical.telemetry_mut();
     canonical_telemetry.set_header_length(0);
     canonical_telemetry.set_body_length(0);
@@ -616,7 +616,7 @@ fn mutate_header_composition_root(bytes: &ProofBytes) -> ProofBytes {
 }
 
 fn corrupt_fri_layer_root(proof: &Proof) -> ProofBytes {
-    let mut mutated = proof.clone();
+    let mut mutated = proof.clone_using_parts();
     if let Some(root) = mutated.merkle_mut().fri_layer_roots.first_mut() {
         if let Some(byte) = root.first_mut() {
             *byte ^= 0x1;


### PR DESCRIPTION
## Summary
- add a `Proof::clone_using_parts` helper that rebuilds a proof through `Proof::from_parts`
- update verifier and test fixtures to clone proofs via the new helper before applying mutations

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68e929dab3c483269d5358a8501b13ce