### PR TITLE
Ensure Proof cloning uses Proof::from_parts

### DIFF
--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -131,7 +131,7 @@ impl FriHandle {
 }
 
 /// Fully decoded proof container mirroring the authoritative specification.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Proof {
     /// Declared proof version (currently `1`).
     #[serde(with = "proof_version_codec")]
@@ -161,6 +161,16 @@ pub struct Proof {
     has_telemetry: bool,
     /// Telemetry frame describing declared lengths and digests.
     telemetry: Telemetry,
+}
+
+impl Clone for Proof {
+    fn clone(&self) -> Self {
+        self.clone_using_parts()
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        *self = source.clone_using_parts();
+    }
 }
 
 impl Proof {


### PR DESCRIPTION
## Summary
- implement a manual `Clone` for `Proof` that delegates to `clone_using_parts`
- ensure all `Proof` clones are reassembled through `Proof::from_parts`

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68e9305385ec8326957d57dc36f535f0