### PR TITLE
Refine proof openings accessors

### DIFF
--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -159,7 +159,7 @@ impl ProofBuilder {
         let fri_handle = FriHandle::new(fri_proof);
         let telemetry_option = TelemetryOption::new(true, telemetry);
 
-        if openings_descriptor.openings().out_of_domain.is_empty() {
+        if openings_descriptor.openings().out_of_domain().is_empty() {
             return Err(VerifyError::EmptyOpenings);
         }
 
@@ -170,7 +170,7 @@ impl ProofBuilder {
 
         let public_digest = compute_public_digest(&public_inputs);
 
-        if openings_descriptor.openings().composition.is_some()
+        if openings_descriptor.openings().composition().is_some()
             && openings_descriptor.merkle().aux_root == [0u8; 32]
         {
             return Err(VerifyError::CompositionInconsistent {
@@ -178,7 +178,7 @@ impl ProofBuilder {
             });
         }
 
-        if openings_descriptor.openings().composition.is_none()
+        if openings_descriptor.openings().composition().is_none()
             && openings_descriptor.merkle().aux_root != [0u8; 32]
         {
             return Err(VerifyError::CompositionInconsistent {
@@ -186,7 +186,7 @@ impl ProofBuilder {
             });
         }
 
-        let composition_commit = if openings_descriptor.openings().composition.is_some() {
+        let composition_commit = if openings_descriptor.openings().composition().is_some() {
             Some(DigestBytes {
                 bytes: openings_descriptor.merkle().aux_root,
             })

--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -465,6 +465,38 @@ pub struct Openings {
     pub out_of_domain: Vec<OutOfDomainOpening>,
 }
 
+impl Openings {
+    /// Returns the Merkle openings covering core trace queries.
+    pub fn trace(&self) -> &TraceOpenings {
+        &self.trace
+    }
+
+    /// Returns a mutable reference to the Merkle openings covering core trace queries.
+    pub fn trace_mut(&mut self) -> &mut TraceOpenings {
+        &mut self.trace
+    }
+
+    /// Returns the optional composition openings, when present.
+    pub fn composition(&self) -> Option<&CompositionOpenings> {
+        self.composition.as_ref()
+    }
+
+    /// Returns a mutable reference to the optional composition openings, when present.
+    pub fn composition_mut(&mut self) -> Option<&mut CompositionOpenings> {
+        self.composition.as_mut()
+    }
+
+    /// Returns the individual out-of-domain openings accompanying the proof.
+    pub fn out_of_domain(&self) -> &Vec<OutOfDomainOpening> {
+        &self.out_of_domain
+    }
+
+    /// Returns a mutable reference to the individual out-of-domain openings.
+    pub fn out_of_domain_mut(&mut self) -> &mut Vec<OutOfDomainOpening> {
+        &mut self.out_of_domain
+    }
+}
+
 /// Merkle opening data covering trace commitments.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TraceOpenings {
@@ -474,6 +506,38 @@ pub struct TraceOpenings {
     pub leaves: Vec<Vec<u8>>,
     /// Authentication paths proving membership for each query.
     pub paths: Vec<MerkleAuthenticationPath>,
+}
+
+impl TraceOpenings {
+    /// Returns the query indices sampled from the FRI transcript.
+    pub fn indices(&self) -> &[u32] {
+        &self.indices
+    }
+
+    /// Returns a mutable reference to the query indices sampled from the FRI transcript.
+    pub fn indices_mut(&mut self) -> &mut Vec<u32> {
+        &mut self.indices
+    }
+
+    /// Returns the leaf payloads revealed for each queried index.
+    pub fn leaves(&self) -> &[Vec<u8>] {
+        &self.leaves
+    }
+
+    /// Returns a mutable reference to the leaf payloads revealed for each queried index.
+    pub fn leaves_mut(&mut self) -> &mut Vec<Vec<u8>> {
+        &mut self.leaves
+    }
+
+    /// Returns the authentication paths proving membership for each query.
+    pub fn paths(&self) -> &[MerkleAuthenticationPath] {
+        &self.paths
+    }
+
+    /// Returns a mutable reference to the authentication paths proving membership for each query.
+    pub fn paths_mut(&mut self) -> &mut Vec<MerkleAuthenticationPath> {
+        &mut self.paths
+    }
 }
 
 /// Merkle opening data covering composition commitments.
@@ -487,11 +551,55 @@ pub struct CompositionOpenings {
     pub paths: Vec<MerkleAuthenticationPath>,
 }
 
+impl CompositionOpenings {
+    /// Returns the query indices sampled from the FRI transcript.
+    pub fn indices(&self) -> &[u32] {
+        &self.indices
+    }
+
+    /// Returns a mutable reference to the query indices sampled from the FRI transcript.
+    pub fn indices_mut(&mut self) -> &mut Vec<u32> {
+        &mut self.indices
+    }
+
+    /// Returns the leaf payloads revealed for each queried index.
+    pub fn leaves(&self) -> &[Vec<u8>] {
+        &self.leaves
+    }
+
+    /// Returns a mutable reference to the leaf payloads revealed for each queried index.
+    pub fn leaves_mut(&mut self) -> &mut Vec<Vec<u8>> {
+        &mut self.leaves
+    }
+
+    /// Returns the authentication paths proving membership for each query.
+    pub fn paths(&self) -> &[MerkleAuthenticationPath] {
+        &self.paths
+    }
+
+    /// Returns a mutable reference to the authentication paths proving membership for each query.
+    pub fn paths_mut(&mut self) -> &mut Vec<MerkleAuthenticationPath> {
+        &mut self.paths
+    }
+}
+
 /// Authentication path for a Merkle opening.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MerkleAuthenticationPath {
     /// Sequence of nodes from the leaf to the root.
     pub nodes: Vec<MerklePathNode>,
+}
+
+impl MerkleAuthenticationPath {
+    /// Returns the sequence of nodes from the leaf to the root.
+    pub fn nodes(&self) -> &[MerklePathNode] {
+        &self.nodes
+    }
+
+    /// Returns a mutable reference to the sequence of nodes from the leaf to the root.
+    pub fn nodes_mut(&mut self) -> &mut Vec<MerklePathNode> {
+        &mut self.nodes
+    }
 }
 
 /// Single node within an authentication path.

--- a/tests/fail_matrix/indices.rs
+++ b/tests/fail_matrix/indices.rs
@@ -31,7 +31,7 @@ fn trace_rejects_unsorted_indices() {
 
     assert_debug_snapshot!(
         "trace_rejects_unsorted_indices",
-        &mutated.proof.openings().trace.indices
+        mutated.proof.openings().trace().indices()
     );
 }
 
@@ -58,7 +58,7 @@ fn trace_rejects_duplicate_indices() {
 
     assert_debug_snapshot!(
         "trace_rejects_duplicate_indices",
-        &mutated.proof.openings().trace.indices
+        mutated.proof.openings().trace().indices()
     );
 }
 
@@ -85,7 +85,7 @@ fn trace_rejects_mismatched_indices() {
 
     assert_debug_snapshot!(
         "trace_rejects_mismatched_indices",
-        &mutated.proof.openings().trace.indices
+        mutated.proof.openings().trace().indices()
     );
 }
 
@@ -115,13 +115,12 @@ fn composition_rejects_unsorted_indices() {
 
     assert_debug_snapshot!(
         "composition_rejects_unsorted_indices",
-        &mutated
+        mutated
             .proof
             .openings()
-            .composition
-            .as_ref()
+            .composition()
             .expect("composition openings available")
-            .indices
+            .indices()
     );
 }
 
@@ -151,13 +150,12 @@ fn composition_rejects_duplicate_indices() {
 
     assert_debug_snapshot!(
         "composition_rejects_duplicate_indices",
-        &mutated
+        mutated
             .proof
             .openings()
-            .composition
-            .as_ref()
+            .composition()
             .expect("composition openings available")
-            .indices
+            .indices()
     );
 }
 
@@ -187,12 +185,11 @@ fn composition_rejects_mismatched_indices() {
 
     assert_debug_snapshot!(
         "composition_rejects_mismatched_indices",
-        &mutated
+        mutated
             .proof
             .openings()
-            .composition
-            .as_ref()
+            .composition()
             .expect("composition openings available")
-            .indices
+            .indices()
     );
 }

--- a/tests/fail_matrix/ood.rs
+++ b/tests/fail_matrix/ood.rs
@@ -29,7 +29,7 @@ fn trace_ood_rejects_core_value_mismatch() {
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::TraceOodMismatch));
 
-    let ood_openings = mutated.proof.openings().out_of_domain.clone();
+    let ood_openings = mutated.proof.openings().out_of_domain().clone();
     assert!(!ood_openings.is_empty(), "mutated proof lost OOD payloads");
 
     assert_debug_snapshot!("trace_ood_mismatch__tampered_out_of_domain", ood_openings);
@@ -59,7 +59,7 @@ fn composition_ood_rejects_value_mismatch() {
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::CompositionOodMismatch));
 
-    let ood_openings = mutated.proof.openings().out_of_domain.clone();
+    let ood_openings = mutated.proof.openings().out_of_domain().clone();
     assert!(!ood_openings.is_empty(), "mutated proof lost OOD payloads");
 
     assert_debug_snapshot!(

--- a/tests/fail_matrix/snapshots.rs
+++ b/tests/fail_matrix/snapshots.rs
@@ -31,19 +31,19 @@ fn freeze_fixture_artifacts() {
     let config = fixture.config();
 
     let openings = proof.openings();
-    let trace_indices = openings.trace.indices.clone();
-    let composition_indices = openings.composition.as_ref().map(|c| c.indices.clone());
+    let trace_indices = openings.trace().indices().to_vec();
+    let composition_indices = openings.composition().map(|c| c.indices().to_vec());
 
     let trace_path_lengths = openings
-        .trace
-        .paths
+        .trace()
+        .paths()
         .iter()
-        .map(|path| path.nodes.len())
+        .map(|path| path.nodes().len())
         .collect::<Vec<_>>();
-    let composition_path_lengths = openings.composition.as_ref().map(|c| {
-        c.paths
+    let composition_path_lengths = openings.composition().map(|c| {
+        c.paths()
             .iter()
-            .map(|path| path.nodes.len())
+            .map(|path| path.nodes().len())
             .collect::<Vec<_>>()
     });
 

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_duplicate_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_duplicate_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 152
-expression: "&mutated.proof.openings().composition.as_ref().expect(\"composition openings available\").indices"
+expression: "mutated.proof.openings().composition().expect(\"composition openings available\").indices()"
 ---
 [
     15,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_mismatched_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_mismatched_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 188
-expression: "&mutated.proof.openings().composition.as_ref().expect(\"composition openings available\").indices"
+expression: "mutated.proof.openings().composition().expect(\"composition openings available\").indices()"
 ---
 [
     1000000,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_unsorted_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__composition_rejects_unsorted_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 116
-expression: "&mutated.proof.openings().composition.as_ref().expect(\"composition openings available\").indices"
+expression: "mutated.proof.openings().composition().expect(\"composition openings available\").indices()"
 ---
 [
     56,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_duplicate_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_duplicate_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 59
-expression: "&mutated.proof.openings().trace.indices"
+expression: "mutated.proof.openings().trace().indices()"
 ---
 [
     15,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_mismatched_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_mismatched_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 86
-expression: "&mutated.proof.openings().trace.indices"
+expression: "mutated.proof.openings().trace().indices()"
 ---
 [
     1000000,

--- a/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_unsorted_indices.snap
+++ b/tests/fail_matrix/snapshots/fail_matrix__indices__trace_rejects_unsorted_indices.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/fail_matrix/indices.rs
 assertion_line: 32
-expression: "&mutated.proof.openings().trace.indices"
+expression: "mutated.proof.openings().trace().indices()"
 ---
 [
     56,

--- a/tests/proof_artifacts.rs
+++ b/tests/proof_artifacts.rs
@@ -124,23 +124,22 @@ fn snapshot_execution_proof_artifacts() {
 
     let trace_paths: Vec<usize> = decoded
         .openings()
-        .trace
-        .paths
+        .trace()
+        .paths()
         .iter()
-        .map(|path| path.nodes.len())
+        .map(|path| path.nodes().len())
         .collect();
     let composition_paths: Option<Vec<usize>> = decoded
         .openings()
-        .composition
-        .as_ref()
-        .map(|comp| comp.paths.iter().map(|path| path.nodes.len()).collect());
+        .composition()
+        .map(|comp| comp.paths().iter().map(|path| path.nodes().len()).collect());
     let trace_indices = {
-        let mut indices = decoded.openings().trace.indices.clone();
+        let mut indices = decoded.openings().trace().indices().to_vec();
         indices.sort_unstable();
         indices
     };
-    let composition_indices = decoded.openings().composition.as_ref().map(|comp| {
-        let mut indices = comp.indices.clone();
+    let composition_indices = decoded.openings().composition().map(|comp| {
+        let mut indices = comp.indices().to_vec();
         indices.sort_unstable();
         indices
     });

--- a/tests/proof_merkle_quaternary.rs
+++ b/tests/proof_merkle_quaternary.rs
@@ -137,8 +137,8 @@ fn quaternary_profile_merkle_tamper_rejected() {
     .expect("proof generation succeeds");
 
     let mut proof = Proof::from_bytes(proof_bytes.as_slice()).expect("decode proof");
-    if let Some(path) = proof.openings_mut().trace.paths.first_mut() {
-        if let Some(node) = path.nodes.get_mut(1) {
+    if let Some(path) = proof.openings_mut().trace_mut().paths_mut().first_mut() {
+        if let Some(node) = path.nodes_mut().get_mut(1) {
             node.sibling[0] ^= 0x01;
         }
     }


### PR DESCRIPTION
## Summary
- add accessor methods to proof opening structures and expose path helpers
- update verifier, serializer, envelope code and tests to use the getters and mutate via `openings_mut`
- refresh fail-matrix snapshots to reflect the new accessor-based expressions

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e94be05ebc8326a3ae73e46db99365