### PR TITLE
Refactor proof wrappers and rename params hash accessors

### DIFF
--- a/src/proof/ser.rs
+++ b/src/proof/ser.rs
@@ -282,7 +282,7 @@ fn serialize_proof_header_from_lengths(
     let mut buffer = Vec::new();
     write_u16(&mut buffer, proof.version());
     write_u8(&mut buffer, encode_proof_kind(*proof.kind()));
-    write_digest(&mut buffer, &proof.param_digest().0.bytes);
+    write_digest(&mut buffer, &proof.params_hash().0.bytes);
     let air_spec_bytes = proof.air_spec_id().clone().bytes();
     write_digest(&mut buffer, &air_spec_bytes.bytes);
 

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -224,10 +224,10 @@ fn validate_header(
         )));
     }
 
-    if proof.param_digest() != &config.param_digest {
+    if proof.params_hash() != &config.param_digest {
         return Err(VerifyError::ParamsHashMismatch);
     }
-    if proof.param_digest() != &context.param_digest {
+    if proof.params_hash() != &context.param_digest {
         return Err(VerifyError::ParamsHashMismatch);
     }
 

--- a/tests/fail_matrix/fixture.rs
+++ b/tests/fail_matrix/fixture.rs
@@ -243,7 +243,7 @@ pub fn flip_header_version(proof: &Proof) -> ProofBytes {
 /// Corrupts a single byte inside the parameter digest.
 pub fn flip_param_digest_byte(proof: &Proof) -> ProofBytes {
     let mut parts = ProofParts::from_proof(proof);
-    parts.param_digest_mut().0.bytes[0] ^= 0x01;
+    parts.params_hash_mut().0.bytes[0] ^= 0x01;
     let mut mutated = parts.into_proof();
     reencode_proof(&mut mutated)
 }
@@ -365,7 +365,7 @@ pub struct MutatedProof {
 #[derive(Debug, Clone)]
 struct ProofParts {
     version: u16,
-    param_digest: ParamDigest,
+    params_hash: ParamDigest,
     public_digest: DigestBytes,
     trace_commit: DigestBytes,
     binding: CompositionBinding,
@@ -388,7 +388,7 @@ impl ProofParts {
 
         Self {
             version: proof.version(),
-            param_digest: proof.param_digest().clone(),
+            params_hash: proof.params_hash().clone(),
             public_digest: proof.public_digest().clone(),
             trace_commit: proof.trace_commit().clone(),
             binding,
@@ -401,7 +401,7 @@ impl ProofParts {
     fn into_proof(self) -> Proof {
         Proof::from_parts(
             self.version,
-            self.param_digest,
+            self.params_hash,
             self.public_digest,
             self.trace_commit,
             self.binding,
@@ -415,8 +415,8 @@ impl ProofParts {
         &mut self.version
     }
 
-    fn param_digest_mut(&mut self) -> &mut ParamDigest {
-        &mut self.param_digest
+    fn params_hash_mut(&mut self) -> &mut ParamDigest {
+        &mut self.params_hash
     }
 
     fn openings(&self) -> &OpeningsDescriptor {

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -634,7 +634,7 @@ fn corrupt_fri_layer_root(proof: &Proof) -> ProofBytes {
 }
 
 fn mutate_param_digest(proof: &mut Proof) {
-    proof.param_digest_mut().0.bytes[0] ^= 0x1;
+    proof.params_hash_mut().0.bytes[0] ^= 0x1;
 }
 
 fn mutate_public_digest(bytes: &ProofBytes) -> ProofBytes {


### PR DESCRIPTION
## Summary
- restructure the `Proof` container to persist binding, openings, FRI and telemetry wrappers directly
- document wrapper responsibilities and update accessors plus method names to expose `params_hash`
- adjust serialization, verification and tests to consume the new wrappers and naming

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e951c332d08326bf259852b1af1eba