### PR TITLE
Rename transcript header digest field to params_hash

### DIFF
--- a/src/proof/prover.rs
+++ b/src/proof/prover.rs
@@ -187,7 +187,7 @@ pub fn build_envelope(
         poseidon_param_id: context.profile.poseidon_param_id.clone(),
         air_spec_id: air_spec_id.clone(),
         proof_kind,
-        param_digest: context.param_digest.clone(),
+        params_hash: context.param_digest.clone(),
     })?;
     transcript.absorb_public_inputs(&public_inputs_bytes)?;
     transcript.absorb_commitment_roots(core_root, Some(aux_root))?;

--- a/src/proof/transcript.rs
+++ b/src/proof/transcript.rs
@@ -89,8 +89,8 @@ pub struct TranscriptHeader {
     pub air_spec_id: AirSpecId,
     /// Proof kind currently being processed.
     pub proof_kind: ProofKind,
-    /// Parameter digest binding global configuration.
-    pub param_digest: ParamDigest,
+    /// Parameter hash binding global configuration.
+    pub params_hash: ParamDigest,
 }
 
 /// Block context fields absorbed into the transcript.
@@ -269,7 +269,7 @@ impl Transcript {
         transcript.absorb_section_raw(TRANSCRIPT_DOMAIN_TAG);
         let proof_kind_code = transcript.proof_kind_code();
         transcript.absorb_section_raw(&proof_kind_code);
-        transcript.absorb_section_raw(&header.param_digest.0.bytes);
+        transcript.absorb_section_raw(&header.params_hash.0.bytes);
 
         Ok(transcript)
     }
@@ -784,7 +784,7 @@ mod tests {
             poseidon_param_id: PoseidonParamId(digest(2)),
             air_spec_id: AirSpecId(digest(3)),
             proof_kind: kind,
-            param_digest: ParamDigest(digest(param_byte)),
+            params_hash: ParamDigest(digest(param_byte)),
         }
     }
 

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -318,7 +318,7 @@ fn precheck_body(
         poseidon_param_id: context.profile.poseidon_param_id.clone(),
         air_spec_id: air_spec_id.clone(),
         proof_kind: transcript_kind,
-        param_digest: context.param_digest.clone(),
+        params_hash: context.param_digest.clone(),
     })
     .map_err(|_| VerifyError::TranscriptOrder)?;
 

--- a/tests/fail_matrix/fixture.rs
+++ b/tests/fail_matrix/fixture.rs
@@ -240,7 +240,7 @@ pub fn flip_header_version(proof: &Proof) -> ProofBytes {
     reencode_proof(&mut mutated)
 }
 
-/// Corrupts a single byte inside the parameter digest.
+/// Corrupts a single byte inside the parameter hash.
 pub fn flip_param_digest_byte(proof: &Proof) -> ProofBytes {
     let mut parts = ProofParts::from_proof(proof);
     parts.params_hash_mut().0.bytes[0] ^= 0x01;
@@ -256,7 +256,7 @@ pub fn flip_public_digest_byte(bytes: &ProofBytes) -> ProofBytes {
     let mut cursor = 0usize;
     cursor += 2; // version
     cursor += 1; // kind
-    cursor += 32; // param digest
+    cursor += 32; // params hash
     cursor += 32; // air spec identifier
 
     let public_len_start = cursor;
@@ -283,7 +283,7 @@ pub fn mismatch_trace_root(bytes: &ProofBytes) -> ProofBytes {
     let mut cursor = 0usize;
     cursor += 2; // version
     cursor += 1; // kind
-    cursor += 32; // param digest
+    cursor += 32; // params hash
     cursor += 32; // air spec identifier
 
     let public_len_start = cursor;

--- a/tests/fail_matrix/header.rs
+++ b/tests/fail_matrix/header.rs
@@ -23,7 +23,7 @@ fn header_bytes(bytes: &ProofBytes) -> Vec<u8> {
     let mut cursor = 0usize;
     cursor += 2; // version
     cursor += 1; // kind
-    cursor += 32; // param digest
+    cursor += 32; // params hash
     cursor += 32; // air spec id
 
     let public_len = u32::from_le_bytes(

--- a/tests/fail_matrix/merkle.rs
+++ b/tests/fail_matrix/merkle.rs
@@ -23,7 +23,7 @@ fn extract_roots(bytes: &ProofBytes) -> ([u8; 32], [u8; 32], [u8; 32]) {
     let mut cursor = 0usize;
     cursor += 2; // version
     cursor += 1; // kind
-    cursor += 32; // param digest
+    cursor += 32; // params hash
     cursor += 32; // air spec identifier
 
     let public_len_start = cursor;

--- a/tests/fail_matrix/telemetry.rs
+++ b/tests/fail_matrix/telemetry.rs
@@ -19,7 +19,7 @@ fn telemetry_frame_bytes(bytes: &ProofBytes) -> Option<Vec<u8>> {
     let mut cursor = 0usize;
     cursor += 2; // version
     cursor += 1; // kind
-    cursor += 32; // param digest
+    cursor += 32; // params hash
     cursor += 32; // air spec id
 
     let public_len = u32::from_le_bytes(

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -407,7 +407,7 @@ fn build_ood_openings(
         poseidon_param_id: context.profile.poseidon_param_id.clone(),
         air_spec_id,
         proof_kind,
-        param_digest: context.param_digest.clone(),
+        params_hash: context.param_digest.clone(),
     })
     .expect("transcript");
 

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -648,7 +648,7 @@ fn header_trace_root_offset(bytes: &[u8]) -> usize {
     let mut cursor = 0usize;
     cursor += 2; // version
     cursor += 1; // kind
-    cursor += 32; // param digest
+    cursor += 32; // params hash
     cursor += 32; // air spec id
     let public_len =
         u32::from_le_bytes(bytes[cursor..cursor + 4].try_into().expect("len")) as usize;
@@ -1535,7 +1535,7 @@ fn generate_proof_propagates_param_digest_mismatch() {
         &wrong_config,
         &setup.prover_context,
     )
-    .expect_err("param digest mismatch propagates");
+    .expect_err("params hash mismatch propagates");
     assert!(matches!(
         error,
         StarkError::InvalidInput("prover_param_digest_mismatch")


### PR DESCRIPTION
## Summary
- rename the transcript header parameter field to `params_hash` and update prover/verifier usage
- refresh test helpers and comments to reference the new params hash terminology

## Testing
- cargo test determinism_across_runs

------
https://chatgpt.com/codex/tasks/task_e_68e95567b9ec8326a78028b8f39a8e0b