### PR TITLE
Refine proof builder to use accessor wrappers

### DIFF
--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -470,6 +470,36 @@ impl MerkleProofBundle {
         }
     }
 
+    /// Returns the core commitment root stored in the bundle.
+    pub fn core_root(&self) -> &[u8; 32] {
+        &self.core_root
+    }
+
+    /// Returns a mutable reference to the core commitment root stored in the bundle.
+    pub fn core_root_mut(&mut self) -> &mut [u8; 32] {
+        &mut self.core_root
+    }
+
+    /// Returns the auxiliary commitment root recorded in the bundle.
+    pub fn aux_root(&self) -> &[u8; 32] {
+        &self.aux_root
+    }
+
+    /// Returns a mutable reference to the auxiliary commitment root recorded in the bundle.
+    pub fn aux_root_mut(&mut self) -> &mut [u8; 32] {
+        &mut self.aux_root
+    }
+
+    /// Returns the FRI layer roots mirrored by the bundle.
+    pub fn fri_layer_roots(&self) -> &[[u8; 32]] {
+        &self.fri_layer_roots
+    }
+
+    /// Returns a mutable reference to the FRI layer roots mirrored by the bundle.
+    pub fn fri_layer_roots_mut(&mut self) -> &mut Vec<[u8; 32]> {
+        &mut self.fri_layer_roots
+    }
+
     /// Assembles a bundle and validates that the provided FRI proof advertises
     /// compatible layer roots. The layer ordering must be identical.
     pub fn from_fri_proof(
@@ -487,7 +517,7 @@ impl MerkleProofBundle {
     /// individual roots to verify that the redundant data is internally
     /// consistent.
     pub fn ensure_consistency(&self, fri_proof: &crate::fri::FriProof) -> Result<(), VerifyError> {
-        if self.fri_layer_roots != fri_proof.layer_roots {
+        if self.fri_layer_roots() != &fri_proof.layer_roots {
             return Err(VerifyError::MerkleVerifyFailed {
                 section: MerkleSection::FriRoots,
             });

--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -517,7 +517,7 @@ impl MerkleProofBundle {
     /// individual roots to verify that the redundant data is internally
     /// consistent.
     pub fn ensure_consistency(&self, fri_proof: &crate::fri::FriProof) -> Result<(), VerifyError> {
-        if self.fri_layer_roots() != &fri_proof.layer_roots {
+        if self.fri_layer_roots() != fri_proof.layer_roots.as_slice() {
             return Err(VerifyError::MerkleVerifyFailed {
                 section: MerkleSection::FriRoots,
             });

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -272,7 +272,7 @@ fn precheck_body(
     block_context: Option<&TranscriptBlockContext>,
     stages: &mut VerificationStages,
 ) -> Result<PrecheckedBody, VerifyError> {
-    if proof.trace_commit().bytes != proof.openings().merkle().core_root {
+    if proof.trace_commit().bytes != *proof.openings().merkle().core_root() {
         return Err(VerifyError::RootMismatch {
             section: MerkleSection::TraceCommit,
         });
@@ -283,7 +283,7 @@ fn precheck_body(
         proof.openings().composition(),
     ) {
         (Some(commit), Some(_)) => {
-            if commit.bytes != proof.openings().merkle().aux_root {
+            if commit.bytes != *proof.openings().merkle().aux_root() {
                 return Err(VerifyError::RootMismatch {
                     section: MerkleSection::CompositionCommit,
                 });
@@ -300,7 +300,7 @@ fn precheck_body(
             });
         }
         (None, None) => {
-            if proof.openings().merkle().aux_root != [0u8; 32] {
+            if proof.openings().merkle().aux_root() != &[0u8; 32] {
                 return Err(VerifyError::RootMismatch {
                     section: MerkleSection::CompositionCommit,
                 });
@@ -308,7 +308,7 @@ fn precheck_body(
         }
     }
 
-    if proof.openings().merkle().fri_layer_roots != proof.fri().fri_proof().layer_roots {
+    if proof.openings().merkle().fri_layer_roots() != &proof.fri().fri_proof().layer_roots {
         return Err(VerifyError::MerkleVerifyFailed {
             section: MerkleSection::FriRoots,
         });
@@ -365,7 +365,13 @@ fn precheck_body(
     let fri_seed = challenges
         .draw_fri_seed()
         .map_err(|_| VerifyError::TranscriptOrder)?;
-    for (layer_index, _) in proof.openings().merkle().fri_layer_roots.iter().enumerate() {
+    for (layer_index, _) in proof
+        .openings()
+        .merkle()
+        .fri_layer_roots()
+        .iter()
+        .enumerate()
+    {
         challenges
             .draw_fri_eta(layer_index)
             .map_err(|_| VerifyError::TranscriptOrder)?;

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -308,7 +308,9 @@ fn precheck_body(
         }
     }
 
-    if proof.openings().merkle().fri_layer_roots() != &proof.fri().fri_proof().layer_roots {
+    if proof.openings().merkle().fri_layer_roots()
+        != proof.fri().fri_proof().layer_roots.as_slice()
+    {
         return Err(VerifyError::MerkleVerifyFailed {
             section: MerkleSection::FriRoots,
         });


### PR DESCRIPTION
## Summary
- update `ProofBuilder::build` to assemble proofs from the new wrapper handles and adopt accessor-based validation checks
- add accessor helpers to `MerkleProofBundle` and update serialization and verifier logic to use them
- rename builder header handling to the `params_hash` terminology while keeping composition binding and telemetry wiring intact

## Testing
- `cargo test --lib proof::envelope::tests::build_smoke`


------
https://chatgpt.com/codex/tasks/task_e_68e963fd4df48326bc1082ad2b898bde