### PR TITLE
Refactor proof accessors in verifier and aggregation

### DIFF
--- a/src/proof/envelope.rs
+++ b/src/proof/envelope.rs
@@ -489,9 +489,9 @@ mod tests {
             .build()
             .expect("build sample proof");
 
-        assert!(proof.telemetry().is_present());
-        assert!(proof.composition().composition_commit().is_some());
-        assert!(proof.telemetry().frame().header_length() > 0);
+        assert!(proof.has_telemetry());
+        assert!(proof.composition_commit().is_some());
+        assert!(proof.telemetry_frame().header_length() > 0);
         assert_ne!(proof.trace_commit().bytes, [0u8; 32]);
 
         proof


### PR DESCRIPTION
## Summary
- switch verifier precheck logic to use Proof wrapper accessors for composition, openings, and telemetry
- update transcript setup and telemetry canonicalization to rely on the new helper methods
- adjust envelope test expectations to check wrapper-based accessors

## Testing
- cargo test proof::aggregation::tests -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e97c89cae88326bb434ab20c4e7e6e