### PR TITLE
Document proof accessors and update error mapping

### DIFF
--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -1542,7 +1542,7 @@ fn generate_proof_propagates_param_digest_mismatch() {
     .expect_err("params hash mismatch propagates");
     assert!(matches!(
         error,
-        StarkError::InvalidInput("prover_param_digest_mismatch")
+        StarkError::InvalidInput("prover_params_hash_mismatch")
     ));
 }
 


### PR DESCRIPTION
## Summary
- reference the new proof accessors and telemetry wrapper in the top-level documentation
- re-export `TelemetryOption` so callers can access the new wrapper from the crate root
- align error codes and docs with the params hash terminology

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68e97eb83be48326b993ba1a3bd73107