### PR TITLE
Update tests for proof wrapper accessors

### DIFF
--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -328,10 +328,10 @@ fn build_envelope(
         bytes: public_digest,
     };
     let trace_commit = DigestBytes {
-        bytes: merkle.core_root,
+        bytes: *merkle.core_root(),
     };
     let composition_commit = Some(DigestBytes {
-        bytes: merkle.aux_root,
+        bytes: *merkle.aux_root(),
     });
     let openings = Openings {
         trace: trace_openings,

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -624,7 +624,11 @@ fn mutate_header_composition_root(bytes: &ProofBytes) -> ProofBytes {
 
 fn corrupt_fri_layer_root(proof: &Proof) -> ProofBytes {
     let mut mutated = proof.clone_using_parts();
-    if let Some(root) = mutated.merkle_mut().fri_layer_roots.first_mut() {
+    if let Some(root) = mutated
+        .merkle_mut()
+        .fri_layer_roots_mut()
+        .first_mut()
+    {
         if let Some(byte) = root.first_mut() {
             *byte ^= 0x1;
         } else {
@@ -638,7 +642,9 @@ fn corrupt_fri_layer_root(proof: &Proof) -> ProofBytes {
 }
 
 fn mutate_param_digest(proof: &mut Proof) {
-    proof.params_hash_mut().0.bytes[0] ^= 0x1;
+    let mut updated = *proof.params_hash().as_bytes();
+    updated[0] ^= 0x1;
+    *proof.params_hash_mut() = ParamDigest(DigestBytes { bytes: updated });
 }
 
 fn mutate_public_digest(bytes: &ProofBytes) -> ProofBytes {


### PR DESCRIPTION
## Summary
- update proof lifecycle helper mutations to use the new proof wrapper accessors
- switch limit tests to derive commitments via Merkle bundle getters before building envelopes
- adjust fail-matrix fixtures to mutate telemetry and parameter digests through accessors

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e9815019108326bbb3bccac2356cca