### PR TITLE
Refine VerifyReport format and verifier pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,9 @@ Parallelisierung zur Laufzeit deaktivieren und Ergebnisse direkt vergleichen.
     FRI-Komposition referenziert, müssen bytegenau den `composition`-Leaves an
     denselben Indizes entsprechen (`CompositionInconsistent` bei Abweichung).
   - Report: Flags setzen (`params_ok`, `public_ok`, `merkle_ok`, `fri_ok`,
-    `composition_ok`), `total_bytes` als echte Serialisierungslänge.
+    `composition_ok`), `total_bytes` als echte Serialisierungslänge, `error`
+    für den ersten Fehler. Der Report spiegelt keinen vollständigen `Proof`
+    mehr wider – Decoder greifen bei Bedarf direkt auf die Proof-Bytes zu.
 - Fehler-Taxonomie (final):
   - `VersionMismatch { expected, got }`
   - `ParamsHashMismatch`
@@ -763,6 +765,8 @@ nightly-Abhängigkeiten.
   - `merkle_ok` nach erfolgreicher Merkle-Prüfung,
   - `fri_ok` nach FRI-Erfolg,
   - `composition_ok` nur falls Composition vorhanden und konsistent.
+- `error` enthält (optional) die erste aufgetretene [`VerifyError`]; der Report
+  enthält keinen eingebetteten Proof mehr.
 - Telemetry wird ignoriert für die Gültigkeit; optional in Report gespiegelt (z. B. Queries, Layers).
 
 **Tests**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,10 @@ pub fn generate_proof(
 /// parameters must match the ones used by the prover; otherwise
 /// [`proof::types::VerifyError::ParamsHashMismatch`] is expected. The proof
 /// [`proof::types::Proof::params_hash`] accessor must therefore agree with the
-/// parameter hash stored by the prover.
+/// parameter hash stored by the prover. The underlying
+/// [`proof::types::VerifyReport`] returned by the verifier summarizes the
+/// deterministic stage flags (`params_ok`, `public_ok`, `merkle_ok`, `fri_ok`,
+/// `composition_ok`), the measured `total_bytes`, and an optional [`VerifyError`].
 pub fn verify_proof(
     kind: ProofKind,
     public_inputs: &PublicInputs<'_>,

--- a/src/proof/api.rs
+++ b/src/proof/api.rs
@@ -72,7 +72,7 @@ impl VerifyProofContract {
 
     /// Output produced by the function.
     pub const OUTPUT: &'static str =
-        "verdict: Accept | Reject(VerifyError) wrapped in VerificationVerdict";
+        "report: VerifyReport{params_ok, public_ok, merkle_ok, fri_ok, composition_ok, total_bytes, error}";
 
     /// Determinism requirements for the function.
     pub const DETERMINISM: &'static [&'static str] = &[
@@ -137,6 +137,11 @@ pub fn generate_proof(
 }
 
 /// Forward declaration of the verify_proof function (no implementation).
+///
+/// The returned [`VerifyReport`] mirrors the deterministic stage flags exposed by
+/// the verifier. Each boolean flag defaults to `false` when the corresponding
+/// stage aborts, `total_bytes` captures the measured envelope length, and
+/// `error` documents the first failure (if any).
 pub fn verify_proof(
     kind: ProofKind,
     public_inputs: &PublicInputs<'_>,

--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -981,11 +981,9 @@ impl TelemetryOption {
     }
 }
 
-/// Structured verification report pairing a decoded proof with the outcome.
+/// Structured verification report describing the outcome of deterministic checks.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VerifyReport {
-    /// Fully decoded proof container.
-    pub proof: Proof,
     /// Flag indicating whether parameter hashing checks succeeded.
     #[serde(default)]
     pub params_ok: bool,
@@ -1005,6 +1003,7 @@ pub struct VerifyReport {
     #[serde(default)]
     pub total_bytes: u64,
     /// Optional verification error captured during decoding or checks.
+    #[serde(default)]
     pub error: Option<VerifyError>,
 }
 

--- a/src/proof/types.rs
+++ b/src/proof/types.rs
@@ -982,7 +982,12 @@ impl TelemetryOption {
 }
 
 /// Structured verification report describing the outcome of deterministic checks.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// The struct implements [`Default`] so all stage flags fall back to `false`,
+/// `total_bytes` defaults to `0`, and `error` becomes `None` when
+/// deserialized from older payloads that omit the newer fields.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct VerifyReport {
     /// Flag indicating whether parameter hashing checks succeeded.
     #[serde(default)]

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -113,17 +113,15 @@ fn precheck_decoded_proof(
     env: DecodedProofEnv<'_, '_>,
     stages: &mut VerificationStages,
 ) -> Result<PrecheckedProof, VerifyError> {
-    if let Err(error) = validate_header(
+    validate_header(
         &proof,
         env.declared_kind,
         env.public_inputs,
         env.config,
         env.context,
         stages,
-    ) {
-        return Err(error);
-    }
-    match precheck_body(
+    )?;
+    let prechecked = precheck_body(
         &proof,
         env.public_inputs,
         env.config,
@@ -131,15 +129,13 @@ fn precheck_decoded_proof(
         env.total_bytes,
         env.block_context,
         stages,
-    ) {
-        Ok(prechecked) => Ok(PrecheckedProof {
-            proof,
-            fri_seed: prechecked.fri_seed,
-            security_level: prechecked.security_level,
-            params: prechecked.params,
-        }),
-        Err(error) => Err(error),
-    }
+    )?;
+    Ok(PrecheckedProof {
+        proof,
+        fri_seed: prechecked.fri_seed,
+        security_level: prechecked.security_level,
+        params: prechecked.params,
+    })
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- reshape `VerifyReport` to carry stage flags, `total_bytes`, and optional errors without embedding decoded proofs
- update the verifier pipeline, public APIs, and documentation to reflect the slimmer report structure
- adjust lifecycle tests to decode proofs from bytes when inspecting telemetry

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea255507448326aa3eb4d306781027