### PR TITLE
Update proof tests for handle-based API

### DIFF
--- a/src/bin/profile_reports.rs
+++ b/src/bin/profile_reports.rs
@@ -218,7 +218,7 @@ fn build_sample_proof(
     let header_bytes = proof
         .serialize_header(&payload)
         .expect("sample proof header serialization");
-    let telemetry = proof.telemetry_mut().frame_mut();
+    let telemetry = proof.telemetry_frame_mut();
     telemetry.set_body_length((payload.len() + 32) as u32);
     telemetry.set_header_length(header_bytes.len() as u32);
     let integrity = compute_integrity_digest(&header_bytes, &payload);

--- a/tests/fail_matrix/snapshots.rs
+++ b/tests/fail_matrix/snapshots.rs
@@ -70,11 +70,11 @@ fn freeze_fixture_artifacts() {
         "proof_bytes_hex": hex_encode(proof_bytes.as_slice()),
         "param_digest_hex": hex_encode(config.param_digest.as_bytes()),
         "roots": {
-            "core": hex_encode(&proof.merkle().core_root),
-            "aux": hex_encode(&proof.merkle().aux_root),
+            "core": hex_encode(proof.merkle().core_root()),
+            "aux": hex_encode(proof.merkle().aux_root()),
             "fri_from_merkle": proof
                 .merkle()
-                .fri_layer_roots
+                .fri_layer_roots()
                 .iter()
                 .map(hex_encode)
                 .collect::<Vec<_>>(),

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -365,7 +365,7 @@ fn build_envelope(
     let header_bytes = proof
         .serialize_header(&payload)
         .expect("proof header serialization");
-    let telemetry = proof.telemetry_mut().frame_mut();
+    let telemetry = proof.telemetry_frame_mut();
     telemetry.set_body_length((payload.len() + 32) as u32);
     telemetry.set_header_length(header_bytes.len() as u32);
     let integrity = compute_integrity_digest(&header_bytes, &payload);

--- a/tests/proof_artifacts.rs
+++ b/tests/proof_artifacts.rs
@@ -164,11 +164,11 @@ fn snapshot_execution_proof_artifacts() {
     let fri_path_summary = summarize_lengths(&fri_layer_path_lengths);
 
     let artifact = serde_json::json!({
-        "trace_root": hex(&decoded.merkle().core_root),
-        "composition_root": hex(&decoded.merkle().aux_root),
+        "trace_root": hex(decoded.merkle().core_root()),
+        "composition_root": hex(decoded.merkle().aux_root()),
         "fri_roots": decoded
             .merkle()
-            .fri_layer_roots
+            .fri_layer_roots()
             .iter()
             .map(hex)
             .collect::<Vec<_>>(),

--- a/tests/ser_structures.rs
+++ b/tests/ser_structures.rs
@@ -140,7 +140,7 @@ fn sample_proof() -> Proof {
     let header_bytes =
         serialize_proof_header(&proof, &payload).expect("proof header serialization");
     let integrity = compute_integrity_digest(&header_bytes, &payload);
-    let telemetry = proof.telemetry_mut().frame_mut();
+    let telemetry = proof.telemetry_frame_mut();
     telemetry.set_header_length(header_bytes.len() as u32);
     telemetry.set_body_length((payload.len() + 32) as u32);
     telemetry.set_integrity_digest(DigestBytes { bytes: integrity });


### PR DESCRIPTION
## Summary
- adjust proof lifecycle telemetry helpers to use the new proof handle accessors
- rebuild failure-matrix and serialization fixtures using handle clones instead of field access
- align proof artifact snapshots and profile report tooling with handle-based Merkle/Fri accessors

## Testing
- cargo test --test proof_lifecycle -- --nocapture
- cargo test --test fail_matrix -- --nocapture
- cargo test --test proof_artifacts -- --nocapture
- cargo test --test ser_structures -- --nocapture
- cargo test --test limits -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68ea3982968c83268ef6d60dd9c22e3e