### PR TITLE
Adjust proof re-exports for new helper handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,9 @@ nightly-Abhängigkeiten.
 
 **Dateien**
 
-- `src/proof/types` (Strukturvertrags: Proof, Openings, MerkleProofBundle, Telemetry, VerifyError, VerifyReport, `PROOF_VERSION = 1`)
+- `src/proof/types` (Strukturvertrag: Proof, CompositionBinding, FriHandle,
+  OpeningsDescriptor, Openings, MerkleProofBundle, TelemetryOption, Telemetry,
+  VerifyError, VerifyReport, `PROOF_VERSION = 1`)
 - `src/proof/ser` (Ser/De für Proof, Openings, Bundle, Telemetry; `serialized_len`)
 - `src/proof/mod` (Reexports)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,11 @@
 //! and aggregation. All functions are intentionally left without
 //! implementations; they simply document the required parameters and the
 //! deterministic sequencing dictated by the specification. Inspectors interact
-//! with strongly typed accessors when reading decoded proofs. Configuration
-//! bindings are surfaced through [`proof::types::Proof::params_hash`], while
-//! optional telemetry is handled by [`proof::types::TelemetryOption`].
+//! with strongly typed accessors when reading decoded proofs, using handles
+//! such as [`proof::CompositionBinding`], [`proof::FriHandle`] and
+//! [`proof::OpeningsDescriptor`]. Configuration bindings are surfaced through
+//! [`proof::types::Proof::params_hash`], while optional telemetry is handled by
+//! [`proof::TelemetryOption`].
 
 pub mod air;
 pub mod config;
@@ -39,7 +41,8 @@ use ser::{SerError, SerKind as SerializationKind};
 
 pub use proof::aggregation::{BatchProofRecord, BatchVerificationOutcome, BlockContext};
 pub use proof::types::{
-    Proof, Telemetry, TelemetryOption, VerifyError, VerifyReport, PROOF_VERSION,
+    CompositionBinding, FriHandle, Openings, OpeningsDescriptor, Proof, Telemetry, TelemetryOption,
+    VerifyError, VerifyReport, PROOF_VERSION,
 };
 use utils::serialization::{ProofBytes, WitnessBlob};
 

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -38,5 +38,8 @@ pub mod public_inputs;
 pub mod transcript;
 
 pub use public_inputs::ProofKind;
-pub use types::{Openings, Proof, Telemetry, VerifyError, VerifyReport};
+pub use types::{
+    CompositionBinding, FriHandle, Openings, OpeningsDescriptor, Proof, Telemetry, TelemetryOption,
+    VerifyError, VerifyReport,
+};
 pub use verifier::verify_proof_bytes as verify;


### PR DESCRIPTION
## Summary
- re-export the new proof helper wrappers alongside Proof, VerifyReport, and VerifyError
- expose the same handles at the crate root and refresh the top-level documentation comment
- update the README proof ABI section to document the revised minimal type set

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68ea3c1e233883269618c23fea9a3b8c