### PR TITLE
Remove verify_proof_bytes alias and update tests

### DIFF
--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -122,17 +122,6 @@ pub fn verify(
     verify_impl(declared_kind, public_inputs, proof_bytes, config, context)
 }
 
-/// Backwards-compatible alias for legacy callers.
-pub fn verify_proof_bytes(
-    declared_kind: ConfigProofKind,
-    public_inputs: &PublicInputs<'_>,
-    proof_bytes: &ProofBytes,
-    config: &ProofSystemConfig,
-    context: &VerifierContext,
-) -> Result<VerifyReport, VerifyError> {
-    verify(declared_kind, public_inputs, proof_bytes, config, context)
-}
-
 fn should_return_report(error: &VerifyError) -> bool {
     matches!(
         error,

--- a/tests/fail_matrix/composition.rs
+++ b/tests/fail_matrix/composition.rs
@@ -1,7 +1,7 @@
 use insta::assert_debug_snapshot;
 use rpp_stark::config::ProofKind as ConfigProofKind;
 use rpp_stark::proof::types::VerifyError;
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 
 use super::{flip_composition_leaf_byte, FailMatrixFixture};
 
@@ -17,7 +17,7 @@ fn composition_rejects_leaf_bytes_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,

--- a/tests/fail_matrix/fri.rs
+++ b/tests/fail_matrix/fri.rs
@@ -1,7 +1,7 @@
 use insta::assert_debug_snapshot;
 use rpp_stark::config::ProofKind as ConfigProofKind;
 use rpp_stark::proof::types::{FriVerifyIssue, MerkleSection, VerifyError};
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 
 use super::{perturb_fri_fold_challenge, FailMatrixFixture};
 
@@ -14,7 +14,7 @@ fn fri_rejects_fold_challenge_tampering() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,

--- a/tests/fail_matrix/header.rs
+++ b/tests/fail_matrix/header.rs
@@ -1,7 +1,7 @@
 use insta::assert_snapshot;
 use rpp_stark::config::ProofKind as ConfigProofKind;
 use rpp_stark::proof::types::VerifyError;
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 use rpp_stark::ser::SerKind;
 use rpp_stark::utils::serialization::ProofBytes;
 
@@ -34,7 +34,7 @@ fn header_rejects_version_bump() {
     let context = fixture.verifier_context();
     let mutated_bytes = flip_header_version(&fixture.proof());
 
-    let err = verify_proof_bytes(
+    let err = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -59,7 +59,7 @@ fn header_rejects_param_digest_mismatch() {
     let context = fixture.verifier_context();
     let mutated_bytes = flip_param_digest_byte(&fixture.proof());
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -85,7 +85,7 @@ fn header_rejects_public_digest_mismatch() {
     let context = fixture.verifier_context();
     let mutated_bytes = flip_public_digest_byte(&fixture.proof_bytes());
 
-    let err = verify_proof_bytes(
+    let err = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -111,7 +111,7 @@ fn header_rejects_excessive_proof_size() {
     context.limits.max_proof_size_bytes = 64;
     let proof_bytes = fixture.proof_bytes();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &proof_bytes,
@@ -137,7 +137,7 @@ fn header_rejects_openings_offset_mismatch() {
     let context = fixture.verifier_context();
     let mutated_bytes = mismatch_openings_offset(&fixture.proof_bytes());
 
-    let err = verify_proof_bytes(
+    let err = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -165,7 +165,7 @@ fn header_rejects_fri_offset_mismatch() {
     let context = fixture.verifier_context();
     let mutated_bytes = mismatch_fri_offset(&fixture.proof_bytes());
 
-    let err = verify_proof_bytes(
+    let err = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -197,7 +197,7 @@ fn header_rejects_telemetry_offset_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let err = verify_proof_bytes(
+    let err = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -229,7 +229,7 @@ fn header_rejects_telemetry_flag_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let err = verify_proof_bytes(
+    let err = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,

--- a/tests/fail_matrix/indices.rs
+++ b/tests/fail_matrix/indices.rs
@@ -1,7 +1,7 @@
 use insta::assert_debug_snapshot;
 use rpp_stark::config::ProofKind as ConfigProofKind;
 use rpp_stark::proof::types::VerifyError;
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 
 use super::{
     duplicate_composition_index, duplicate_trace_index, mismatch_composition_indices,
@@ -17,7 +17,7 @@ fn trace_rejects_unsorted_indices() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,
@@ -44,7 +44,7 @@ fn trace_rejects_duplicate_indices() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,
@@ -71,7 +71,7 @@ fn trace_rejects_mismatched_indices() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,
@@ -101,7 +101,7 @@ fn composition_rejects_unsorted_indices() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,
@@ -136,7 +136,7 @@ fn composition_rejects_duplicate_indices() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,
@@ -171,7 +171,7 @@ fn composition_rejects_mismatched_indices() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,

--- a/tests/fail_matrix/merkle.rs
+++ b/tests/fail_matrix/merkle.rs
@@ -1,7 +1,7 @@
 use insta::assert_debug_snapshot;
 use rpp_stark::config::ProofKind as ConfigProofKind;
 use rpp_stark::proof::types::{MerkleSection, VerifyError};
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 use rpp_stark::utils::serialization::ProofBytes;
 use std::convert::TryInto;
 
@@ -126,7 +126,7 @@ fn merkle_rejects_header_root_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let err = verify_proof_bytes(
+    let err = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -172,7 +172,7 @@ fn merkle_rejects_corrupted_trace_path() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,
@@ -214,7 +214,7 @@ fn merkle_rejects_inconsistent_trace_paths() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,

--- a/tests/fail_matrix/ood.rs
+++ b/tests/fail_matrix/ood.rs
@@ -1,7 +1,7 @@
 use insta::assert_debug_snapshot;
 use rpp_stark::config::ProofKind as ConfigProofKind;
 use rpp_stark::proof::types::VerifyError;
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 
 use super::{flip_ood_composition_value, flip_ood_trace_core_value, FailMatrixFixture};
 
@@ -17,7 +17,7 @@ fn trace_ood_rejects_core_value_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,
@@ -47,7 +47,7 @@ fn composition_ood_rejects_value_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated.bytes,

--- a/tests/fail_matrix/telemetry.rs
+++ b/tests/fail_matrix/telemetry.rs
@@ -1,7 +1,7 @@
 use insta::assert_snapshot;
 use rpp_stark::config::ProofKind as ConfigProofKind;
 use rpp_stark::proof::types::VerifyError;
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 use rpp_stark::utils::serialization::ProofBytes;
 
 use super::fixture::header_layout;
@@ -45,7 +45,7 @@ fn telemetry_rejects_header_length_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -77,7 +77,7 @@ fn telemetry_rejects_body_length_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
@@ -109,7 +109,7 @@ fn telemetry_rejects_integrity_digest_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -23,7 +23,7 @@ use rpp_stark::proof::types::{
     OutOfDomainOpening, Proof, Telemetry, TelemetryOption, TraceOpenings, VerifyError,
     PROOF_ALPHA_VECTOR_LEN, PROOF_MIN_OOD_POINTS, PROOF_VERSION,
 };
-use rpp_stark::proof::verifier::verify_proof_bytes;
+use rpp_stark::proof::verifier::verify;
 use rpp_stark::utils::serialization::{DigestBytes, ProofBytes};
 
 use rpp_stark::fri::{FriProof, FriQueryLayerProof, FriQueryProof, FriSecurityLevel};
@@ -38,7 +38,7 @@ fn proof_size_limit_is_enforced() {
     let proof_bytes = build_envelope(&config, &context, &inputs, 1, 1, 4);
     let public_inputs = inputs.as_public_inputs();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &proof_bytes,
@@ -62,7 +62,7 @@ fn fri_layer_overflow_is_rejected() {
     let proof_bytes = build_envelope(&config, &context, &inputs, 3, 1, 4);
     let public_inputs = inputs.as_public_inputs();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &proof_bytes,
@@ -88,7 +88,7 @@ fn fri_query_budget_limit_is_enforced() {
     let proof_bytes = build_envelope(&config, &context, &inputs, 1, 3, 4);
     let public_inputs = inputs.as_public_inputs();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &proof_bytes,
@@ -129,7 +129,7 @@ fn trace_degree_bound_is_enforced() {
     let proof_bytes = build_envelope(&config, &context, &inputs, 1, 1, 4);
     let public_inputs = inputs.as_public_inputs();
 
-    let report = verify_proof_bytes(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &proof_bytes,

--- a/tests/proof_lifecycle.rs
+++ b/tests/proof_lifecycle.rs
@@ -256,7 +256,7 @@ fn verification_report_records_total_bytes_and_telemetry() {
     .expect("proof generation succeeds");
 
     let declared_kind = map_public_to_config_kind(ProofKind::Execution);
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &proof_bytes,
@@ -352,7 +352,7 @@ fn verification_rejects_tampered_telemetry_fields() {
     let tampered_header_bytes = ProofBytes::new(
         serialize_proof(&tampered_header).expect("serialize tampered header proof"),
     );
-    let header_report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let header_report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &tampered_header_bytes,
@@ -380,7 +380,7 @@ fn verification_rejects_tampered_telemetry_fields() {
     let tampered_digest_bytes = ProofBytes::new(
         serialize_proof(&tampered_digest).expect("serialize tampered digest proof"),
     );
-    let digest_report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let digest_report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &tampered_digest_bytes,
@@ -416,7 +416,7 @@ fn verification_report_flags_param_digest_flip() {
     let mutated_bytes = reencode_proof(&mut proof);
 
     let declared_kind = map_public_to_config_kind(ProofKind::Execution);
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &mutated_bytes,
@@ -441,7 +441,7 @@ fn verification_report_marks_all_stages_on_success_path() {
     let proof_bytes = fixture.proof_bytes();
     let declared_kind = map_public_to_config_kind(public_inputs.kind());
 
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &proof_bytes,
@@ -475,7 +475,7 @@ fn verification_report_flags_public_stage_failure() {
     let mutated_bytes = reencode_proof(&mut mutated_proof);
     let declared_kind = map_public_to_config_kind(public_inputs.kind());
 
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &mutated_bytes,
@@ -516,7 +516,7 @@ fn verification_report_flags_merkle_stage_failure() {
     let mutated_bytes = corrupt_fri_layer_root(&fixture.proof());
     let declared_kind = map_public_to_config_kind(public_inputs.kind());
 
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &mutated_bytes,
@@ -560,7 +560,7 @@ fn verification_report_flags_composition_stage_failure() {
         flip_composition_leaf_byte(&fixture.proof()).expect("composition openings present");
     let declared_kind = map_public_to_config_kind(public_inputs.kind());
 
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &mutated.bytes,
@@ -602,7 +602,7 @@ fn verification_report_flags_fri_stage_failure() {
     let mutated = perturb_fri_fold_challenge(&fixture.proof());
     let declared_kind = map_public_to_config_kind(public_inputs.kind());
 
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &mutated.bytes,
@@ -732,7 +732,7 @@ fn proof_decode_rejects_public_digest_tampering() {
     assert!(matches!(decode_error, VerifyError::PublicDigestMismatch));
 
     let declared_kind = map_public_to_config_kind(ProofKind::Execution);
-    let verify_err = rpp_stark::proof::verifier::verify_proof_bytes(
+    let verify_err = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &mutated,
@@ -1037,7 +1037,7 @@ fn verification_report_flags_fri_challenge_flip() {
     let mutated_bytes = reencode_proof(&mut proof);
 
     let declared_kind = map_public_to_config_kind(ProofKind::Execution);
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &mutated_bytes,
@@ -1178,7 +1178,7 @@ fn verification_report_flags_header_trace_root_mismatch() {
 
     let tampered = mutate_header_trace_root(&proof_bytes);
     let declared_kind = map_public_to_config_kind(ProofKind::Execution);
-    let err = rpp_stark::proof::verifier::verify_proof_bytes(
+    let err = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &tampered,
@@ -1252,7 +1252,7 @@ fn verification_report_flags_header_composition_root_mismatch() {
 
     let tampered = mutate_header_composition_root(&proof_bytes);
     let declared_kind = map_public_to_config_kind(ProofKind::Execution);
-    let err = rpp_stark::proof::verifier::verify_proof_bytes(
+    let err = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &tampered,
@@ -1654,7 +1654,7 @@ fn verification_report_flags_proof_size_overflow() {
     let mut tight_context = setup.verifier_context.clone();
     tight_context.limits.max_proof_size_bytes = 64; // enforce a strict budget
 
-    let report = rpp_stark::proof::verifier::verify_proof_bytes(
+    let report = rpp_stark::proof::verifier::verify(
         declared_kind,
         &public_inputs,
         &proof_bytes,


### PR DESCRIPTION
## Summary
- remove the deprecated `verify_proof_bytes` alias from the verifier
- update the proof test suite to call the canonical `verify` entry point

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68eab8ed893c8326ac45edf19534df2a