### PR TITLE
Refactor verifier results to always return reports

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -870,7 +870,7 @@ mod tests {
         let public_inputs = sample_public_inputs();
         let proof_bytes = ProofBytes::new(Vec::new());
 
-        let result = verify(
+        let report = verify(
             ProofKind::Tx,
             &public_inputs,
             &proof_bytes,
@@ -878,6 +878,9 @@ mod tests {
             &hisec_context,
         );
 
-        assert!(matches!(result, Err(VerifyError::ParamsHashMismatch)));
+        assert!(matches!(
+            report.error,
+            Some(VerifyError::ParamsHashMismatch)
+        ));
     }
 }

--- a/src/proof/api.rs
+++ b/src/proof/api.rs
@@ -24,10 +24,10 @@ impl ProofLifecycleSpec {
     pub const STEPS: &'static [&'static str] = &[
         "ingest_public_inputs",
         "prepare_contexts",
-        "execute_prover_pipeline",
+        "describe_envelope_structure",
         "assemble_envelope",
-        "single_verify",
-        "optional_batch_verify",
+        "emit_header_report",
+        "optional_batch_summary",
     ];
 }
 
@@ -155,13 +155,14 @@ pub fn verify_proof(
     }
 
     let declared_kind = map_public_to_config_kind(kind);
-    super::verifier::verify(
+    let report = super::verifier::verify(
         declared_kind,
         public_inputs,
         proof_bytes,
         config,
         verifier_context,
-    )
+    );
+    Ok(report)
 }
 
 /// Forward declaration of the batch_verify function (no implementation).

--- a/tests/fail_matrix/composition.rs
+++ b/tests/fail_matrix/composition.rs
@@ -23,8 +23,7 @@ fn composition_rejects_leaf_bytes_mismatch() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     let reason = match error {

--- a/tests/fail_matrix/fri.rs
+++ b/tests/fail_matrix/fri.rs
@@ -20,8 +20,7 @@ fn fri_rejects_fold_challenge_tampering() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("verification report must be produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     let issue = match error {

--- a/tests/fail_matrix/header.rs
+++ b/tests/fail_matrix/header.rs
@@ -35,14 +35,15 @@ fn header_rejects_version_bump() {
     let mutated_bytes = flip_header_version(&fixture.proof());
 
     let declared_kind = map_public_to_config_kind(public_inputs.kind());
-    let err = verify(
+    let report = verify(
         declared_kind,
         &public_inputs,
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect_err("version mismatch must error");
+    );
+
+    let err = report.error.expect("version mismatch must error");
 
     assert!(matches!(err, VerifyError::VersionMismatch { .. }));
 
@@ -67,8 +68,7 @@ fn header_rejects_param_digest_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected failure");
     assert!(matches!(error, VerifyError::ParamsHashMismatch));
@@ -108,8 +108,7 @@ fn header_rejects_public_digest_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected failure");
     assert!(matches!(error, VerifyError::PublicDigestMismatch));
@@ -149,8 +148,7 @@ fn header_rejects_excessive_proof_size() {
         &proof_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected failure");
     assert!(matches!(error, VerifyError::ProofTooLarge { .. }));
@@ -189,8 +187,7 @@ fn header_rejects_openings_offset_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected failure");
     assert!(matches!(
@@ -232,8 +229,7 @@ fn header_rejects_fri_offset_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected failure");
     assert!(matches!(
@@ -279,8 +275,7 @@ fn header_rejects_telemetry_offset_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected failure");
     assert!(matches!(
@@ -326,8 +321,7 @@ fn header_rejects_telemetry_flag_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected failure");
     assert!(matches!(

--- a/tests/fail_matrix/indices.rs
+++ b/tests/fail_matrix/indices.rs
@@ -23,8 +23,7 @@ fn trace_rejects_unsorted_indices() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::IndicesNotSorted));
@@ -50,8 +49,7 @@ fn trace_rejects_duplicate_indices() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::IndicesDuplicate { .. }));
@@ -77,8 +75,7 @@ fn trace_rejects_mismatched_indices() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::IndicesMismatch));
@@ -107,8 +104,7 @@ fn composition_rejects_unsorted_indices() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::IndicesNotSorted));
@@ -142,8 +138,7 @@ fn composition_rejects_duplicate_indices() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::IndicesDuplicate { .. }));
@@ -177,8 +172,7 @@ fn composition_rejects_mismatched_indices() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::IndicesMismatch));

--- a/tests/fail_matrix/merkle.rs
+++ b/tests/fail_matrix/merkle.rs
@@ -126,14 +126,15 @@ fn merkle_rejects_header_root_mismatch() {
     let config = fixture.config();
     let context = fixture.verifier_context();
 
-    let err = verify(
+    let report = verify(
         ConfigProofKind::Tx,
         &public_inputs,
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect_err("root mismatch must error");
+    );
+
+    let err = report.error.expect("root mismatch must error");
 
     assert!(matches!(
         err,
@@ -178,8 +179,7 @@ fn merkle_rejects_corrupted_trace_path() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(
@@ -220,8 +220,7 @@ fn merkle_rejects_inconsistent_trace_paths() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::EmptyOpenings));

--- a/tests/fail_matrix/ood.rs
+++ b/tests/fail_matrix/ood.rs
@@ -23,8 +23,7 @@ fn trace_ood_rejects_core_value_mismatch() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::TraceOodMismatch));
@@ -53,8 +52,7 @@ fn composition_ood_rejects_value_mismatch() {
         &mutated.bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::CompositionOodMismatch));

--- a/tests/fail_matrix/telemetry.rs
+++ b/tests/fail_matrix/telemetry.rs
@@ -51,8 +51,7 @@ fn telemetry_rejects_header_length_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::HeaderLengthMismatch { .. }));
@@ -83,8 +82,7 @@ fn telemetry_rejects_body_length_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::BodyLengthMismatch { .. }));
@@ -115,8 +113,7 @@ fn telemetry_rejects_integrity_digest_mismatch() {
         &mutated_bytes,
         &config,
         &context,
-    )
-    .expect("report produced");
+    );
 
     let error = report.error.expect("expected verification failure");
     assert!(matches!(error, VerifyError::IntegrityDigestMismatch));

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -44,8 +44,7 @@ fn proof_size_limit_is_enforced() {
         &proof_bytes,
         &config,
         &context,
-    )
-    .expect("verify report");
+    );
 
     assert!(matches!(
         report.error,
@@ -68,8 +67,7 @@ fn fri_layer_overflow_is_rejected() {
         &proof_bytes,
         &config,
         &context,
-    )
-    .expect("verify report");
+    );
 
     assert_eq!(
         report.error,
@@ -94,8 +92,7 @@ fn fri_query_budget_limit_is_enforced() {
         &proof_bytes,
         &config,
         &context,
-    )
-    .expect("verify report");
+    );
 
     assert_eq!(
         report.error,
@@ -135,8 +132,7 @@ fn trace_degree_bound_is_enforced() {
         &proof_bytes,
         &config,
         &context,
-    )
-    .expect("verify report");
+    );
 
     assert_eq!(report.error, Some(VerifyError::DegreeBoundExceeded));
 }


### PR DESCRIPTION
## Summary
- update the verifier implementation to always return `VerifyReport` objects that carry failures in the `error` field
- adjust the public API, aggregation helpers, and documentation to reflect the report-first contract
- refresh unit tests to assert on `VerifyReport.error` and `VerificationVerdict` outcomes instead of expecting transport errors

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68eac45d9d748326aa7e265dce567a4b