### PR TITLE
Add hex-literal dev dependency for embedded proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "insta"
 version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +692,7 @@ dependencies = [
  "bincode",
  "blake2",
  "criterion",
+ "hex-literal",
  "insta",
  "postcard",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ blake2 = "0.10"
 [dev-dependencies]
 bincode = "1"
 insta = { version = "1", features = ["json"] }
+hex-literal = "0.4"
 proptest = "1"
 serde_json = "1"
 


### PR DESCRIPTION
## Summary
- add the hex-literal dev dependency to support embedded proof bytes in tests and snapshots

## Testing
- cargo metadata --no-deps --format-version=1 | jq '.packages[].name'

------
https://chatgpt.com/codex/tasks/task_e_68eadc60978c83269678a3522f0a578f