### PR TITLE
Add STWO interop documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to `rpp-stark` are documented in this file. The structure fo
 - Optional `backend-rpp-stark` feature exposing chain-integration adapters for
   felts, digests and deterministic hashing, including proof-size limit mapping
   helpers and STWO fixture tests.
+- (2025-10-12) Add STWO interop documentation (no ABI change). ABI-Änderungen
+  erfordern PROOF_VERSION++ und Snapshot-Update.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Each arrow corresponds to a module under `src/air`:
 | Transcript | [`src/transcript/mod.rs`](src/transcript/mod.rs) | 4 | Label ordering for Fiat–Shamir challenges. |
 | FRI | [`src/fri`](src/fri) | 7 | Query schedule derived from transcript seeds. |
 
+## Interop-Dokumentation
+
+- [STWO-Interoperabilität](docs/STWO_INTEROP.md)
+- [Public-Inputs-Encoding](docs/PUBLIC_INPUTS_ENCODING.md)
+- [Proof-Size-Gate](docs/PROOF_SIZE_GATE.md)
+
 ### Trace and public-input schema
 
 ```

--- a/docs/PROOF_SIZE_GATE.md
+++ b/docs/PROOF_SIZE_GATE.md
@@ -1,0 +1,22 @@
+# Proof-Size-Gate
+
+## Zweck
+Das Größen-Gate schützt Verifier und Nodes vor DoS durch übergroße Proofs. Es vergleicht die tatsächliche Serialisierungslänge eines Proofs mit der konfigurierten Obergrenze `proof.max_size_kb` und spiegelt das Ergebnis über `VerifyError::ProofTooLarge` wider.【F:src/proof/envelope.rs†L228-L235】【F:src/proof/types.rs†L1240-L1268】
+
+## Messmethode
+1. Proof wird vollständig serialisiert: Header-Bytes, Payload-Bytes sowie das 32-Byte-Integritätsdigest werden summiert (`bytes_total`).【F:src/proof/envelope.rs†L220-L235】
+2. Der Grenzwert `limit_bytes = max_size_kb × 1024` wird aus den STARK-Parametern entnommen.【F:src/proof/envelope.rs†L228-L235】【F:src/params/types.rs†L338-L349】
+3. Überschreitet `bytes_total` den Grenzwert, schlägt der Builder/Verifier mit `ProofTooLarge { max_kb, got_kb }` fehl; die Kilobyte-Werte sind aufgerundet (`div_ceil(1024)`).【F:src/proof/envelope.rs†L228-L235】【F:src/proof/verifier.rs†L460-L463】
+
+## Node-Mapping
+- Die Node-Konfiguration hält denselben Grenzwert in Bytes (`limits.max_proof_size_bytes`). Profile binden diese Ressourcengrenzen an das ParamDigest, wodurch beide Seiten dieselbe Obergrenze teilen.【F:src/config/mod.rs†L268-L324】
+- Beim Prover wird `max_proof_size_bytes` in Kibibyte umgerechnet (`bytes_to_kib`) und als `proof.max_size_kb` in den Proof-Parametern gespeichert.【F:src/proof/prover.rs†L278-L305】
+- Der Verifier vergleicht erneut `total_bytes` mit `limits.max_proof_size_bytes`, wodurch Node- und Proof-Konfiguration konsistent bleiben.【F:src/proof/verifier.rs†L460-L463】
+
+## Grenzfälle
+- Proofs unterhalb der Grenze (z. B. 511 KiB bei `max_size_kb = 512`) werden akzeptiert; `got_kb` entspricht der aufgerundeten Größe und bleibt ≤ `max_kb`.
+- Proofs oberhalb der Grenze (z. B. 513 KiB bei `max_size_kb = 512`) lösen deterministisch `ProofTooLarge` aus; die Differenz wird durch das aufgerundete `got_kb` signalisiert.
+
+## Fehlerverhalten & Logging
+- Der Verifier meldet den Fehler über `VerifyError::ProofTooLarge { max_kb, got_kb }`; Tests prüfen, dass das Flag `verification_report_flags_proof_size_overflow` gesetzt wird und `got_kb > max_kb` ist.【F:README.md†L124-L135】【F:tests/proof_lifecycle.rs†L914-L947】
+- Nodes sollen den Fehler protokollieren und entsprechende Metriken setzen. Weitere Logging-Vorgaben werden im Node-Handbuch ergänzt (TBD, Quelle: README Hinweis auf Mapping `max_proof_size_bytes`).【F:README.md†L1011-L1011】

--- a/docs/PUBLIC_INPUTS_ENCODING.md
+++ b/docs/PUBLIC_INPUTS_ENCODING.md
@@ -1,0 +1,68 @@
+# Public-Inputs-Encoding
+
+## Zweck
+Diese Spezifikation fixiert die kanonische Byte-Kodierung sämtlicher Public Inputs, damit externe STWO-Nodes den `public_digest` deterministisch nachrechnen können.【F:src/proof/public_inputs.rs†L1-L6】
+
+## Allgemeine Regeln
+- Alle Ganzzahlen und Feldwerte werden Little-Endian kodiert; variable Abschnitte besitzen ein vorgeschaltetes `u32`-Längenfeld.【F:src/proof/public_inputs.rs†L1-L6】【F:src/proof/ser.rs†L86-L125】
+- Die Feldreihenfolge ist fix und abhängig vom Proof-Typ (`ProofKind`). Zur Laufzeit dürfen keine Sortierungen oder Umsortierungen stattfinden.【F:src/proof/public_inputs.rs†L45-L104】【F:src/proof/ser.rs†L86-L157】
+- Es existiert kein Padding zwischen Feldern; Bytes werden unmittelbar hintereinander geschrieben.【F:src/proof/ser.rs†L86-L157】
+
+## Feldtabellen
+### Execution (`ProofKind::Execution`)
+| Reihenfolge | Feld | Typ | Länge (Byte) | Encoding | Quelle |
+|-------------|------|-----|--------------|----------|--------|
+| 1 | `version` | `u8` (`V1` → `0x01`) | 1 | Wert direkt | 【F:src/proof/ser.rs†L86-L101】
+| 2 | `program_digest` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L101-L103】
+| 3 | `trace_length` | `u32` | 4 | LE | 【F:src/proof/ser.rs†L103-L105】
+| 4 | `trace_width` | `u32` | 4 | LE | 【F:src/proof/ser.rs†L103-L109】
+| 5 | `body_len` | `u32` | 4 | LE (vor Body) | 【F:src/proof/ser.rs†L109-L113】
+| 6 | `body` | Bytes | `body_len` | Rohbytes | 【F:src/proof/ser.rs†L109-L113】
+
+### Aggregation (`ProofKind::Aggregation`)
+| Reihenfolge | Feld | Typ | Länge (Byte) | Encoding | Quelle |
+|-------------|------|-----|--------------|----------|--------|
+| 1 | `version` | `u8` (`V1`) | 1 | Wert direkt | 【F:src/proof/ser.rs†L113-L130】
+| 2 | `circuit_digest` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L122-L128】
+| 3 | `leaf_count` | `u32` | 4 | LE | 【F:src/proof/ser.rs†L126-L130】
+| 4 | `root_digest` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L126-L133】
+| 5 | `body_len` | `u32` | 4 | LE | 【F:src/proof/ser.rs†L133-L136】
+| 6 | `body` | Bytes | `body_len` | Rohbytes | 【F:src/proof/ser.rs†L133-L136】
+
+### Recursion (`ProofKind::Recursion`)
+| Reihenfolge | Feld | Typ | Länge (Byte) | Encoding | Quelle |
+|-------------|------|-----|--------------|----------|--------|
+| 1 | `version` | `u8` (`V1`) | 1 | Wert direkt | 【F:src/proof/ser.rs†L136-L155】
+| 2 | `depth` | `u8` | 1 | Wert direkt | 【F:src/proof/ser.rs†L146-L151】
+| 3 | `boundary_digest` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L146-L153】
+| 4 | `recursion_seed` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L146-L155】
+| 5 | `body_len` | `u32` | 4 | LE | 【F:src/proof/ser.rs†L151-L157】
+| 6 | `body` | Bytes | `body_len` | Rohbytes | 【F:src/proof/ser.rs†L151-L157】
+
+### Post-Quantum VRF (`ProofKind::VrfPostQuantum`)
+| Reihenfolge | Feld | Typ | Länge (Byte) | Encoding | Quelle |
+|-------------|------|-----|--------------|----------|--------|
+| 1 | `version` | `u8` (`V1`) | 1 | Wert direkt | 【F:src/proof/ser.rs†L157-L188】
+| 2 | `public_key_commit` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L167-L177】
+| 3 | `prf_param_digest` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L167-L177】
+| 4 | `rlwe_param_id` | 32-Byte-Identifier | 32 | Rohbytes | 【F:src/proof/ser.rs†L177-L183】【F:src/vrf/mod.rs†L34-L63】
+| 5 | `vrf_param_id` | 32-Byte-Identifier | 32 | Rohbytes | 【F:src/proof/ser.rs†L177-L183】【F:src/vrf/mod.rs†L44-L63】
+| 6 | `transcript_version_id` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L183-L188】【F:src/config/mod.rs†L104-L114】
+| 7 | `field_id` | `u16` | 2 | LE | 【F:src/proof/ser.rs†L183-L188】【F:src/vrf/mod.rs†L18-L27】
+| 8 | `context_digest` | Digest | 32 | Rohbytes | 【F:src/proof/ser.rs†L183-L188】
+| 9 | `body_len` | `u32` | 4 | LE | 【F:src/proof/ser.rs†L188-L193】
+| 10 | `body` | Bytes | `body_len` | Rohbytes | 【F:src/proof/ser.rs†L188-L193】
+
+## Digest-Berechnung
+Der Public-Inputs-Digest wird strikt als `public_digest = Blake2s("RPP-PI-V1" || kind.code() || encode(public_inputs))` berechnet; `Hasher::finalize()` liefert dabei ein 32-Byte-Ergebnis. Alle Teilnehmer müssen denselben Präfix (`"RPP-PI-V1"`) und Proof-Kind-Code verwenden.【F:src/proof/aggregation.rs†L185-L194】【F:src/hash/deterministic.rs†L134-L167】
+
+## Golden Check
+Um einen Digest zu prüfen, führt der Node folgende Schritte aus:
+1. Public-Input-Felder gemäß obigen Tabellen in ein Byte-Array serialisieren.
+2. Body-Längenfelder (`u32` LE) setzen und anschließend die Body-Bytes anhängen.
+3. Den Proof-Kind-Code (`ProofKind::code()`) als einzelnes Byte voranstellen.【F:src/proof/public_inputs.rs†L23-L40】【F:src/proof/aggregation.rs†L185-L194】
+4. Den Präfix `"RPP-PI-V1"` voranstellen und alles mit Blake2s (32-Byte-Ausgabe) hashen.【F:src/proof/aggregation.rs†L185-L194】【F:src/hash/deterministic.rs†L134-L167】
+5. Das Ergebnis muss mit dem im Proof gelieferten `public_digest` übereinstimmen; Abweichungen führen zu `PublicDigestMismatch` im Verifier.【F:README.md†L392-L399】
+
+## Kompatibilität & Versionierung
+Eine Änderung der Feldreihenfolge, Feldtypen oder Hash-Parameter ändert den Digest und erfordert einen `PROOF_VERSION`-Bump sowie aktualisierte Snapshots laut Änderungspolitik.【F:src/proof/types.rs†L11-L36】【F:README.md†L934-L938】

--- a/docs/STWO_INTEROP.md
+++ b/docs/STWO_INTEROP.md
@@ -1,0 +1,48 @@
+# STWO-Interoperabilität
+
+## Zweck & Geltungsbereich
+Dieses Dokument beschreibt, wie ein externer STWO-Node die von `rpp-stark` erzeugten Beweise bytegenau reproduzieren und prüfen kann. Der Fokus liegt auf Hash- und Merkle-Parametern, Transcript-Orchestrierung, Public-Digest-Bindungen, Size-Gates sowie der Bereitstellung künftiger Golden-Vector-Artefakte.【F:src/transcript/mod.rs†L1-L27】【F:README.md†L374-L408】
+
+## Digest-Familie & Länge
+Alle transcript- und Merkle-bezogenen Hashes verwenden den deterministischen Blake2s-Backend `Hasher<Blake2sInteropHasher>`, der immer 32-Byte-Digests liefert. Adapter für Poseidon oder Rescue re-exportieren weiterhin exakt 32 Byte, so dass alle extern sichtbaren Roots und Digests STWO-kompatibel bleiben.【F:src/hash/deterministic.rs†L134-L167】【F:src/hash/deterministic.rs†L211-L337】
+
+## Domain-Separation
+- **Merkle-Leaf/Node:** Vor jedem Hash wird ein Node-Tag (`0x00` für Leaves, `0x01` für innere Knoten) vorangestellt; anschließend folgt `domain_sep` aus den STARK-Parametern.【F:src/merkle/mod.rs†L5-L16】
+- **Trace-/Composition-Merkle-Kontexte:** Spezifische Transcript-Kontexte `MerkleTrace` und `MerkleComp` liefern 8-Byte-LE-Tags (`0x5250505f54524345`, `0x5250505f4d455243`) und trennen Trace- bzw. Composition-Flows.【F:src/transcript/types.rs†L10-L39】
+- **FRI-Kontext:** Der Transcript-Kontext `Fri` (Tag `0x5250505f4652495f`) isoliert FRI-spezifische Bindungen.【F:src/transcript/types.rs†L10-L39】
+- **Transcript-Labels:** Jede Absorption nutzt feste 16-Byte-Tags je Label (`ParamsHash`, `ProtocolTag`, `Seed`, `PublicInputsDigest`, `TraceRoot`, `CompRoot`, `FriRoot(i)`, `FriFoldChallenge(i)`, `QueryCount`, `QueryIndexStream`, `ProofClose`); Versionierung erfolgt über `PROOF_VERSION`。【F:src/transcript/types.rs†L62-L124】【F:src/proof/types.rs†L11-L36】
+- Alle Tags sind fixiert und versioniert; Änderungen erfordern einen `PROOF_VERSION`-Bump laut Änderungspolitik.【F:README.md†L934-L938】
+
+## Merkle-Parameter
+- **Arity:** Standard ist binär; quaternäre Bäume sind zulässig und behalten Rightmost-Child-Duplication bei ungerader Blattzahl.【F:src/merkle/mod.rs†L5-L16】
+- **Leaf-Layout:** Jedes Leaf besteht aus `leaf_width` Feldelementen in Little-Endian Byte-Reihenfolge ohne zusätzliche Präfixe. Die Reihenfolge folgt dem globalen `lde.order`-Layout (Row/Col-Major) und muss konsistent übernommen werden.【F:src/merkle/mod.rs†L8-L13】【F:README.md†L320-L325】
+- **Digest-Länge:** Merkle-Digests sind 32 Byte Blake2s-Ausgaben.【F:src/hash/merkle.rs†L20-L24】
+
+## Transcript-Reihenfolge
+Der Fiat–Shamir-Transcript absorbiert und emittiert Werte strikt in der dokumentierten Reihenfolge: `ParamsHash → ProtocolTag → Seed → PublicInputsDigest → TraceRoot → TraceChallengeA → (optional) CompRoot/CompChallengeA → FRI-Layer (Root, Fold) → QueryCount → QueryIndexStream → ProofClose`. Diese Sequenz muss bei der Reproduktion exakt nachgezogen werden.【F:src/transcript/mod.rs†L7-L23】【F:README.md†L302-L311】【F:README.md†L394-L402】
+
+## Query-Indizes
+Query-Indizes werden ausschließlich lokal aus dem Transcript erzeugt. Der Verifier verwendet den FRI-Seed, rekonstruiert alle Fold-Challenges, leitet den Query-Seed ab und berechnet `q = fri.queries` Positionen innerhalb `N = 2^(domain_log2)`. Anschließend werden die Indizes in aufsteigender Reihenfolge ohne Duplikate ausgegeben; das Resultat muss exakt `openings.trace.indices` entsprechen.【F:src/proof/verifier.rs†L393-L433】【F:src/proof/verifier.rs†L604-L682】【F:src/fri/proof.rs†L360-L377】【F:README.md†L398-L404】【F:README.md†L430-L434】
+
+## Proof-ABI Referenz
+- **Proof-Layout & Fehler-Taxonomie:** README-Sektion „Proof-Envelope & Verifier“ dokumentiert Header-Reihenfolge, optionale Felder, Fehlernamen und Size-Gate-Regeln.【F:README.md†L374-L428】
+- **Openings-Bundles & Query-Regeln:** README-Bereich „Query-Indizes“ wiederholt die Pflicht zur lokalen Generierung und den Abgleich mit `openings.trace.indices`. Eine konsolidierte ABI-Seite ist noch offen (`PROOF_ABI.md` TBD).【F:README.md†L430-L434】
+- **Telemetry & Reporting:** README beschreibt das Reporting inklusive `ProofTooLarge`-Flag; dedizierte Telemetry-Doku wird künftig gebündelt.【F:README.md†L392-L417】
+
+## Public-Inputs-Digest
+Externe Nodes müssen die Byte-Kodierung der Public Inputs exakt nach `docs/PUBLIC_INPUTS_ENCODING.md` erzeugen und anschließend den Digest gemäß dortiger Hash-Regel berechnen. Abweichungen führen zu `PublicDigestMismatch`.【F:README.md†L302-L308】【F:README.md†L392-L399】
+
+## Size-Gate
+Proofs dürfen die in `proof.max_size_kb` hinterlegte Grenze nicht überschreiten. Die Messung basiert auf der tatsächlichen Serialisierungslänge (Header + Payload + Integritätsdigest). Siehe `docs/PROOF_SIZE_GATE.md` für das Node-Mapping zu `max_proof_size_bytes` und Fehlerverhalten (`ProofTooLarge`).【F:src/proof/envelope.rs†L228-L235】【F:src/proof/verifier.rs†L460-L463】
+
+## Golden Vectors
+Folgende Referenzartefakte werden in einem separaten Schritt unter `vectors/stwo/mini/…` eingefroren:
+- Parameter-Bytes (`params.bin`)
+- Public-Inputs-Bytes (`public_inputs.bin`)
+- Proof-Bytes (`proof.bin`)
+- Merkle-Roots (`trace_root.bin`, `comp_root.bin`)
+- Transcript-Challenges (`fri_fold_challenges.bin`, `query_seed.bin`)
+- Query-Liste (`query_indices.bin`)
+
+## Änderungspolitik
+Jede Änderung an Digest-Familie, Domain-Tags, Transcript-Sequenz oder am Proof-ABI erzwingt einen `PROOF_VERSION`-Bump sowie eine dokumentierte Snapshot-Aktualisierung im CHANGELOG. Diese Disziplin ist bereits in README und CHANGELOG verankert.【F:src/proof/types.rs†L11-L36】【F:README.md†L934-L938】【F:CHANGELOG.md†L1-L34】


### PR DESCRIPTION
## Summary
- add STWO interoperability guide linking transcript, merkle and query rules for STWO nodes
- document canonical public inputs byte encoding and digest computation
- describe the proof size gate configuration and node mapping

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68eafa7e005483269901380734210642