### PR TITLE
Document snapshot and lint policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ All notable changes to `rpp-stark` are documented in this file. The structure fo
 - Regenerate snapshots after intentional ABI changes by running `cargo test -p rpp-stark -- --nocapture` followed by `cargo insta review` and commit the approved diffs.
 - If snapshots change without bumping `PROOF_VERSION`, halt the review and decide whether the change is a bug or requires an ABI bump.
 
+### ABI-Änderungspolitik
+
+- Jede Änderung am Proof-ABI (Feldreihenfolge, Endianness, Tags, Längenfelder,
+  Domain-Tags, Hashfamilie, Public-Inputs-Encoding) erfordert `PROOF_VERSION++`
+  inklusive Snapshot-Update und kurzer Beschreibung des Effekts.
+
+### Snapshots-Änderungen
+
+- Snapshots dürfen nur angepasst werden, wenn `PROOF_VERSION++` im selben Pull
+  Request erfolgt und der Grund im Changelog dokumentiert ist.
+
+### Golden-Vector
+
+- Der Interop-Vektor unter `vectors/stwo/mini` fungiert als Golden-Quelle.
+  Änderungen sind nur nach obiger ABI-Policy zulässig.
+
 ## [Unreleased]
 
 ### ABI
@@ -29,6 +45,7 @@ All notable changes to `rpp-stark` are documented in this file. The structure fo
   helpers and STWO fixture tests.
 - (2025-10-12) Add STWO interop documentation (no ABI change). ABI-Änderungen
   erfordern PROOF_VERSION++ und Snapshot-Update.
+- (2025-10-12) Clippy clean, Snapshot & Changelog policies added (no ABI change).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ Pull requests must pass all of these checks before merging.
 
 Der Workflow [`snapshot-guard`](.github/workflows/snapshot-guard.yml) verhindert Merges, sobald Proof-/Params-Snapshots geändert wurden, ohne dass gleichzeitig `PROOF_VERSION` erhöht und im [`CHANGELOG.md`](CHANGELOG.md) dokumentiert wurde. Wer Snapshots aktualisiert, muss den Version-Bump in [`src/proof/types.rs`](src/proof/types.rs) sowie eine kurze ABI-Notiz im Changelog hinzufügen, damit der Guard wieder grünes Licht gibt. Weitere Hintergründe zu den eingefrorenen Golden-Vectors liefert [docs/STWO_INTEROP.md](docs/STWO_INTEROP.md).
 
+Eine vollständige Übersicht über alle eingefrorenen Artefakte, ihre Ablageorte
+und die Änderungsregeln bündelt [docs/SNAPSHOTS.md](docs/SNAPSHOTS.md).
+
+### Linting & Style
+
+- `cargo clippy --locked -- -D warnings` muss lokal und in CI sauber laufen.
+- Neue `#[allow(...)]`-Attribute sind nur zulässig, wenn eine nahegelegene
+  Begründung (Kommentar) dokumentiert, weshalb die Abweichung für das ABI oder
+  deterministische Layout zwingend ist.
+- Stil-Anpassungen sollen minimalinvasiv sein; keine API- oder Signaturänderung
+  als Teil von Lint-Fixes.
+
 ## Projekt-Blueprint
 
 Die folgende Spezifikation beschreibt die Zielarchitektur der Bibliothek

--- a/docs/PROOF_ABI.md
+++ b/docs/PROOF_ABI.md
@@ -1,0 +1,66 @@
+# Proof ABI quick reference
+
+The proof envelope is versioned via `PROOF_VERSION` (see
+[`src/proof/types.rs`](../src/proof/types.rs)) and is frozen to guarantee byte
+compatibility with existing verifiers. Any change to the byte layout requires a
+`PROOF_VERSION` bump, updated snapshots and a changelog entry.
+
+## Envelope layout (v1)
+
+```
++----------------------+----------------------------------------------------+
+| Field                | Description                                        |
++======================+====================================================+
+| u16 proof_version    | Must equal `PROOF_VERSION` (currently `1`).        |
+| [u8;32] params_hash  | Hash of the parameter profile used by the prover.  |
+| [u8;32] public_digest| Digest of the canonical public inputs.             |
+| Digest trace_commit  | Merkle root of the trace openings.                 |
+| u8 has_comp          | `1` if a composition commitment follows.           |
+| Digest comp_commit?  | Optional Merkle root for the composition openings. |
+| FriProof fri         | Versioned FRI proof structure (`ser/` encoding).    |
+| Openings openings    | Trace/composition opening bundles.                 |
+| u8 has_telemetry     | `1` if telemetry data follows.                     |
+| Telemetry telemetry? | Optional telemetry frame (`total_bytes`, stats).    |
++----------------------+----------------------------------------------------+
+```
+
+All integers use little-endian encoding. Digest fields are raw byte strings; the
+proof format does not reinterpret their endianness.
+
+## Transcript ordering
+
+Verifiers reconstruct the Fiat–Shamir transcript strictly in this order:
+
+1. `params_hash`
+2. Protocol tag and seed from the parameter profile
+3. `public_digest`
+4. `trace_commit`
+5. Optional `comp_commit`
+6. Each FRI layer root (`fri.roots`)
+7. Fold challenges and query schedule as dictated by `FriProof`
+
+All sampled challenges (α vector, out-of-domain points, query indices) must be
+reproducible from the transcript alone; proofs never carry pre-sampled
+challenges.
+
+## Openings structure
+
+The openings block is composed of:
+
+- `trace` – indices, leaves and authentication paths for the execution trace.
+- `composition` – optional bundle aligned with the FRI composition queries.
+- `aux` – optional auxiliary openings carrying additional witness data.
+
+Each bundle serializes as counts (`u32`), sorted indices (`u32`), leaf bytes and
+Merkle paths. Indices must be unique and sorted in ascending order.
+
+## Telemetry frame
+
+When present, telemetry records:
+
+- The serialized proof length in bytes
+- Declared FRI security parameters (query budget, cap size, cap degree)
+- Optional profiling counters used by CI reporting
+
+Telemetry is ignored by the verifier logic but must be well-formed when
+`has_telemetry = 1`.

--- a/docs/SNAPSHOTS.md
+++ b/docs/SNAPSHOTS.md
@@ -1,0 +1,136 @@
+# Snapshot policy
+
+Snapshots freeze deterministic proof artefacts so changes to the proof ABI or
+critical encodings cannot slip in unnoticed. They mirror the byte-level layout of
+the prover outputs and serve as regression fixtures for the verifier and the CI
+snapshot guard.
+
+## Locations
+
+The repository hosts three snapshot families:
+
+- `vectors/stwo/mini/*` – interoperable "golden" vectors shared with STWO.
+- `tests/snapshots/*.snap` – canonical proof, Merkle, FRI and serialization
+  fixtures used by unit and integration tests.
+- `tests/fail_matrix/snapshots/*.snap` – negative fixtures capturing how the
+  verifier reports malformed proofs.
+
+## File reference
+
+### STWO golden vector (interop)
+
+- `vectors/stwo/mini/README.md` – background on the interop bundle and how the
+  vector is produced.
+- `vectors/stwo/mini/challenges.json` – Fiat–Shamir challenges for every proof
+  phase.
+- `vectors/stwo/mini/indices.json` – sorted query indices used by the openings.
+- `vectors/stwo/mini/params.bin` – canonical parameter block referenced by the
+  proof.
+- `vectors/stwo/mini/proof.bin` – byte-for-byte proof envelope.
+- `vectors/stwo/mini/proof_report.json` – verifier status report for
+  `proof.bin`.
+- `vectors/stwo/mini/public_digest.hex` – digest the verifier derives from the
+  public inputs.
+- `vectors/stwo/mini/public_inputs.bin` – canonical public-input payload.
+- `vectors/stwo/mini/roots.json` – Merkle and FRI roots emitted by the prover.
+
+### Canonical proof artefacts (`tests/snapshots`)
+
+- `fri_end_to_end__fri_end_to_end_hisec_deep_proof.snap` – high-security FRI
+  proof bytes for the deep configuration.
+- `fri_end_to_end__fri_end_to_end_standard_proof.snap` – standard profile FRI
+  proof bytes.
+- `fri_proof_serialization__fri_proof_v1_bytes.snap` – serialization snapshot of
+  a canonical `FriProof` structure.
+- `merkle_roundtrip__merkle_aux_bin.snap` – auxiliary Merkle bundle encoding.
+- `merkle_roundtrip__merkle_proof_bin.snap` – Merkle proof bytes for trace
+  openings.
+- `merkle_roundtrip__merkle_root_bin.snap` – canonical Merkle root bytes.
+- `params_roundtrip__profile_hisec_hash.snap` – digest of the high-security
+  parameter profile.
+- `params_roundtrip__profile_hisec_params.snap` – serialized high-security
+  parameter profile.
+- `params_roundtrip__profile_x8_hash.snap` – digest of the default ×8 profile.
+- `params_roundtrip__profile_x8_params.snap` – serialized default ×8 profile.
+- `proof_artifacts__execution_proof_artifacts.snap` – golden proof envelope,
+  transcript and Merkle bundle artefacts.
+- `ser_primitives__digest_with_tag.snap` – digest serialization with
+  domain-separation tags.
+- `ser_structures__fri_proof_bytes.snap` – reference encoding of the FRI proof
+  structure.
+- `ser_structures__merkle_proof_bytes.snap` – reference encoding of a Merkle
+  proof.
+- `ser_structures__proof_bytes.snap` – serialized proof envelope bytes.
+- `transcript_determinism__transcript_profile_x8.snap` – deterministic transcript
+  challenge stream for the ×8 profile.
+
+### Failure matrix fixtures (`tests/fail_matrix/snapshots`)
+
+- `fail_matrix__composition__rejects_leaf_bytes_mismatch__indices.snap` –
+  offending indices when composition leaves diverge.
+- `fail_matrix__composition__rejects_leaf_bytes_mismatch__leaves.snap` – mutated
+  composition leaves used in the rejection case.
+- `fail_matrix__composition__rejects_leaf_bytes_mismatch__reason.snap` –
+  rejection reason emitted by the verifier.
+- `fail_matrix__fri__fri_rejects_fold_challenge_tampering_challenges.snap` –
+  tampered fold challenges triggering a FRI failure.
+- `fail_matrix__fri__fri_rejects_fold_challenge_tampering_error.snap` – verifier
+  error emitted for the tampered fold challenge.
+- `fail_matrix__fri__fri_rejects_fold_challenge_tampering_issue.snap` – issue
+  report backing the fold-challenge tampering scenario.
+- `fail_matrix__header__header_rejects_excessive_proof_size.snap` – proof-size
+  overflow rejection.
+- `fail_matrix__header__header_rejects_fri_offset_mismatch.snap` – mismatch
+  between declared and actual FRI offsets.
+- `fail_matrix__header__header_rejects_openings_offset_mismatch.snap` – mismatch
+  between declared and actual openings offsets.
+- `fail_matrix__header__header_rejects_param_digest_mismatch.snap` – parameter
+  digest mismatch rejection.
+- `fail_matrix__header__header_rejects_public_digest_mismatch.snap` – public
+  digest mismatch rejection.
+- `fail_matrix__header__header_rejects_telemetry_flag_mismatch.snap` – mismatch
+  between telemetry flag and payload presence.
+- `fail_matrix__header__header_rejects_telemetry_offset_mismatch.snap` – mismatch
+  between declared and actual telemetry offsets.
+- `fail_matrix__header__header_rejects_version_bump.snap` – version bump without
+  ABI upgrade.
+- `fail_matrix__indices__composition_rejects_duplicate_indices.snap` – duplicate
+  indices for composition openings.
+- `fail_matrix__indices__composition_rejects_mismatched_indices.snap` –
+  mismatched composition indices.
+- `fail_matrix__indices__composition_rejects_unsorted_indices.snap` – unsorted
+  composition indices.
+- `fail_matrix__indices__trace_rejects_duplicate_indices.snap` – duplicate trace
+  indices.
+- `fail_matrix__indices__trace_rejects_mismatched_indices.snap` – mismatched
+  trace indices.
+- `fail_matrix__indices__trace_rejects_unsorted_indices.snap` – unsorted trace
+  indices.
+- `fail_matrix__merkle__merkle_rejects_corrupted_trace_path.snap` – corrupted
+  trace Merkle path rejection.
+- `fail_matrix__merkle__merkle_rejects_header_root_mismatch.snap` – mismatch
+  between header root and openings payload.
+- `fail_matrix__merkle__merkle_rejects_inconsistent_trace_paths.snap` –
+  inconsistent trace path rejection.
+- `fail_matrix__ood__composition_ood_mismatch__tampered_out_of_domain.snap` –
+  tampered composition out-of-domain point.
+- `fail_matrix__ood__trace_ood_mismatch__tampered_out_of_domain.snap` – tampered
+  trace out-of-domain point.
+- `fail_matrix__snapshots__fail_matrix_fixture_artifacts.snap` – umbrella
+  snapshot enumerating all fail-matrix artefacts.
+- `fail_matrix__telemetry__telemetry_rejects_body_length_mismatch__frame.snap`
+  – telemetry body length mismatch fixture.
+- `fail_matrix__telemetry__telemetry_rejects_header_length_mismatch__frame.snap`
+  – telemetry header length mismatch fixture.
+- `fail_matrix__telemetry__telemetry_rejects_integrity_digest_mismatch__frame.snap`
+  – telemetry integrity digest mismatch fixture.
+
+## Change control
+
+- Snapshots may only change alongside a `PROOF_VERSION` bump.
+- Document the rationale in `CHANGELOG.md` whenever a snapshot update lands.
+- Run `cargo test snapshot_profiles -- --exact` or `cargo insta review` to
+  accept the new artefacts and ensure the CI snapshot guard passes.
+- The `snapshot-guard` GitHub Action and the interop job reject pull requests
+  that touch snapshots without the corresponding version bump and changelog
+  entry.


### PR DESCRIPTION
## Summary
- add proof ABI quick reference and snapshot policy documentation
- reference snapshot policy from README and codify lint requirements
- extend CHANGELOG with ABI/snapshot policy details and maintenance entry

## Testing
- cargo clippy -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68eb6ff817088326aa499f5cce63ff99