### PR TITLE
Prepare v1.0.0-beta release metadata

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,32 @@
+name: release-on-tag
+
+on:
+  push:
+    tags:
+      - rpp-stark-v*
+
+jobs:
+  release:
+    name: Build & Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run tests
+        run: cargo test --locked
+
+      - name: Dry-run publish
+        run: cargo publish --locked --dry-run
+
+      - name: Create GitHub release draft
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          body_path: docs/RELEASE_NOTES.md
+          tag_name: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,25 +34,12 @@ All notable changes to `rpp-stark` are documented in this file. The structure fo
 
 ## [Unreleased]
 
-### ABI
+No unreleased changes.
 
-- Proof envelope, transcript, and Merkle bundle serialization are frozen at `PROOF_VERSION = 1`; deterministic snapshots gate regressions in `tests/snapshots/proof_artifacts__execution_proof_artifacts.snap`.
+## [1.0.0-beta] - 2025-10-12
 
-### Added
-
-- Optional `backend-rpp-stark` feature exposing chain-integration adapters for
-  felts, digests and deterministic hashing, including proof-size limit mapping
-  helpers and STWO fixture tests.
-- (2025-10-12) Add STWO interop documentation (no ABI change). ABI-Änderungen
-  erfordern PROOF_VERSION++ und Snapshot-Update.
-- (2025-10-12) Clippy clean, Snapshot & Changelog policies added (no ABI change).
-
-### Changed
-
-- (2025-10-12) Bump MSRV to 1.79 (no API changes).
-- Raised the minimum supported Rust version (MSRV) and CI toolchain to 1.79 to align with deterministic builds (see `RELEASE_NOTES.md`).
-
-### Known gaps / follow-up
-
-- Parameter snapshot guard ("Param-Snapshot-Gate") is still manual; introduce a CI job that rejects changes to parameter digests without a documented justification.
-- Re-evaluate the MSRV 1.79 bump for downstream consumers before tagging the next release; include compatibility notes once a release candidate is prepared.
+- Added: Proof-Envelope & Verifier (Header→Transcript→Queries→Merkle→FRI→Composition→Report)
+- Added: Fail-Matrix & Golden Vectors
+- Added: Snapshot-Guard (CI) & Interop-Golden-Vector-Check
+- Changed: MSRV 1.79
+- Note: ABI frozen at PROOF_VERSION = 1 (no ABI change in this release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,23 @@ No unreleased changes.
 - Added: Snapshot-Guard (CI) & Interop-Golden-Vector-Check
 - Changed: MSRV 1.79
 - Note: ABI frozen at PROOF_VERSION = 1 (no ABI change in this release)
+
+### ABI
+
+- Proof envelope, transcript, and Merkle bundle serialization are frozen at `PROOF_VERSION = 1`; deterministic snapshots gate regressions in `tests/snapshots/proof_artifacts__execution_proof_artifacts.snap`.
+
+### Added
+
+- Optional `backend-rpp-stark` feature exposing chain-integration adapters for felts, digests and deterministic hashing, including proof-size limit mapping helpers and STWO fixture tests.
+- (2025-10-12) Add STWO interop documentation (no ABI change). ABI-Änderungen erfordern PROOF_VERSION++ und Snapshot-Update.
+- (2025-10-12) Clippy clean, Snapshot & Changelog policies added (no ABI change).
+
+### Changed
+
+- (2025-10-12) Bump MSRV to 1.79 (no API changes).
+- Raised the minimum supported Rust version (MSRV) and CI toolchain to 1.79 to align with deterministic builds (see `RELEASE_NOTES.md`).
+
+### Known gaps / follow-up
+
+- Parameter snapshot guard ("Param-Snapshot-Gate") is still manual; introduce a CI job that rejects changes to parameter digests without a documented justification.
+- Re-evaluate the MSRV 1.79 bump for downstream consumers before tagging the next release; include compatibility notes once a release candidate is prepared.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rpp-stark"
-version = "0.1.0"
+version = "1.0.0-beta"
 dependencies = [
  "bincode",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpp-stark"
-version = "0.1.0"
+version = "1.0.0-beta"
 edition = "2021"
 authors = ["RPP Core Team"]
 description = "Deterministic STARK proof engine for the RPP blockchain."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rpp-stark
 
+[![Latest release](https://img.shields.io/badge/latest-v1.0.0--beta-blue)](docs/RELEASE_NOTES.md)
+
 ## AIR pipeline overview
 
 The AIR layer stitches together the execution trace, polynomial commitments, and

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,9 @@
+# Release Checklist
+
+- [ ] Align all `Cargo.toml` package versions with the release tag (v1.0.0-beta).
+- [ ] Confirm `PROOF_VERSION` remains correct or bump it alongside snapshot updates if the ABI changed.
+- [ ] Regenerate and review Golden Vectors and snapshots; ensure the snapshot guard passes locally.
+- [ ] Update `CHANGELOG.md` and `docs/RELEASE_NOTES.md` with highlights, compatibility, and upgrade notes.
+- [ ] Verify MSRV (1.79) and stable-only toolchains in CI matrices.
+- [ ] Tag the repository with `rpp-stark-v1.0.0-beta` and push the tag.
+- [ ] Draft the GitHub release referencing `docs/RELEASE_NOTES.md` and link to deterministic fixtures.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,25 @@
+# rpp-stark v1.0.0-beta Release Notes
+
+## Overview
+First beta of the STWO-compatible `rpp-stark` proof system targeting production readiness while keeping the proof ABI frozen.
+
+## Highlights
+- Proof envelope and verifier fully cover Header → Transcript → Queries → Merkle → FRI → Composition → Report.
+- Fail-Matrix coverage across the proving pipeline.
+- Deterministic Golden Vectors for regression detection.
+- Snapshot-Guard ensures CI enforces PROOF_VERSION discipline for serialized artifacts.
+- Interop CI validates the STWO Golden Vector set on every change.
+
+## Compatibility
+- Minimum supported Rust version (MSRV): 1.79.
+- Builds and tests run on stable toolchains only; no nightly features required.
+- Proof ABI remains stable at `PROOF_VERSION = 1` for this beta.
+
+## Known Limitations
+- Additional execution profiles and backend integrations are planned for upcoming betas.
+- Parameter snapshot automation beyond proof artifacts will follow in future releases.
+
+## Upgrade Notes
+- Respect the existing `PROOF_VERSION` policy: bump the constant and document the change if the serialized proof layout evolves.
+- Review snapshot updates guarded by CI to ensure any serialization changes are intentional and documented.
+- Downstream consumers should verify their snapshot baselines against the Golden Vectors before deployment.


### PR DESCRIPTION
## Summary
- bump the crate version to 1.0.0-beta and add a matching changelog entry
- publish release documentation, checklist, and README badge for the beta tag
- add a release workflow to run tests and draft the GitHub release when tags are pushed

## Testing
- not run (meta-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eb71aa1df88326b804ced7d33759bd