### PR TITLE
Use shared proof version constant in Merkle proof builder

### DIFF
--- a/src/merkle/proof.rs
+++ b/src/merkle/proof.rs
@@ -4,7 +4,7 @@ use super::traits::MerkleHasher;
 use super::tree::CommitAux;
 use super::types::{Digest, Leaf, MerkleArityExt, MerkleError, ProofNode};
 
-const PROOF_VERSION: u16 = 1;
+use crate::proof::types::PROOF_VERSION;
 
 /// Canonical Merkle opening containing a batch of indices.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary
- import the global `PROOF_VERSION` constant into the Merkle proof helpers instead of redefining it locally

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68eb7c1a9fcc832696352a1808ef8c38